### PR TITLE
Fixed case in HVAC signal

### DIFF
--- a/spec/Signal/Cabin/HVAC.vspec
+++ b/spec/Signal/Cabin/HVAC.vspec
@@ -47,6 +47,6 @@
   type: Boolean
   description: Is rear defroster active.
 
-- isAirConditioningActive:
+- IsAirConditioningActive:
   type: Boolean
   description: Is Air conditioning active.


### PR DESCRIPTION
The signal IsAirConditioningActive was originally written lowercase.
Changed to uppercase as submitted through
https://github.com/GENIVI/vehicle_signal_specification/issues/16.

Signed-off-by: Rudolf J Streif <rstreif@jaguarlandrover.com>