### PR TITLE
Allow appending and modification of nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ TO BE REPLACED BY SI REFERENCE.
 
 Unit type  | Domain        | Description
 :----------|:--------------|:-------------
-k/h        | Speed         | Kilometers per hour
+km/h       | Speed         | Kilometers per hour
 m/s        | Speed         | Meters per hour
 celsius    | Temperature   | Degrees Celsius
 mbar       | Pressure      | millibar

--- a/spec/Signal/OBD/OBD.vspec
+++ b/spec/Signal/OBD/OBD.vspec
@@ -93,7 +93,7 @@
   
 - Speed:
   type: float
-  unit: k/h
+  unit: km/h
   description: PID 0D - Vehicle speed
   
 - TimingAdvance:
@@ -526,10 +526,10 @@
   unit: celsius
   description: PID 3D - Catalyst temperature from bank 2, sensor 1
   
-- Catalyst.Bank2.Temperature1:
+- Catalyst.Bank2.Temperature2:
   type: float
   unit: celsius
-  description: PID 3F - Catalyst temperature from bank 1, sensor 2
+  description: PID 3F - Catalyst temperature from bank 2, sensor 2
   
 - PidsC:
   type: uint32

--- a/tools/vspec.py
+++ b/tools/vspec.py
@@ -221,7 +221,6 @@ def load_flat_model(file_name, prefix, include_paths):
 
     def yaml_construct_mapping(node, deep=False):
         mapping = yaml.constructor.Constructor.construct_mapping(loader, node, deep=deep)
-
         # Find the name of the branch / signal and convert
         # it to a dictionary element '$name$'
         for key, val in mapping.iteritems():
@@ -446,9 +445,20 @@ def create_nested_model(flat_model, file_name):
         # Locate the correct branch in the tree
         parent_branch = find_branch(deep_model, name_list[:-1], 0)
 
-        # Delete redundant element
-
-        parent_branch["children"][name] = elem
+        # If an element with name is already in the parent branch
+        # we update its fields with the fields from the new element
+        if name in parent_branch["children"]:
+            old_elem = parent_branch["children"][name]
+            print "Found: " + str(old_elem)
+            # never update the type
+            elem.pop("type", None)
+            # concatenate file names
+            fname = "{}:{}".format(old_elem["$file_name$"], elem["$file_name$"])
+            old_elem.update(elem)
+            old_elem["$file_name$"] = fname
+            print "Set: " + str(parent_branch["children"][name])
+        else:
+            parent_branch["children"][name] = elem
 
     return deep_model
         


### PR DESCRIPTION

    Allow appending and modification of signals
    
    The specification allows appending and modification of signals defined
    in one branch by the same signal in another branch. For example the default
    signal Drivetrain.Transmission.Speed defined as
    
    - Speed:
      type: Int32
      min: -250
      max: 250
      unit: m/s
      description: Vehicle speed, as sensed by the gearbox.
    
    in spec/Signal/Drivetrain/Transmission.vspec could have some fields adjusted
    by a private branch spec/Private/OEM/Drivetrain/Transmission.vspec
    
    - Speed:
      min: -10
    
    to just update the minimum speed.
    
    Previously, that did not work as the entire node was replaced resulting in
    a 'crippled' node. That is resolved. All fields, except for type, can be modified
    and new fields can be added.
