### PR TITLE
Unified all files and artifacts under the same license

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,7 @@
-**(C) 2016 Jaguar Land Rover - All rights reserved.**<br>
+**(C) 2016 Jaguar Land Rover**<br>
 
-All documents in this repository are licensed under the Creative
-Commons Attribution 4.0 International (CC BY 4.0). Click
-[here](https://creativecommons.org/licenses/by/4.0/) for details.
-All code in this repository is licensed under Mozilla Public License
-v2 (MPLv2). Click [here](https://www.mozilla.org/en-US/MPL/2.0/) for
-details.
+All files and artifacts in this repository are licensed under the
+provisions of the license provided by the LICENSE file in this repository.
 
 # VEHICLE SIGNAL SPECIFICATION
 This repository specifies a set of vehicle signals that can be used in

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -1,12 +1,8 @@
 
-**(C) 2016 Jaguar Land Rover - All rights reserved.**<br>
+**(C) 2016 Jaguar Land Rover**<br>
 
-All documents in this repository are licensed under the Creative
-Commons Attribution 4.0 International (CC BY 4.0). Click
-[here](https://creativecommons.org/licenses/by/4.0/) for details.
-All code in this repository is licensed under Mozilla Public License
-v2 (MPLv2). Click [here](https://www.mozilla.org/en-US/MPL/2.0/) for
-details.
+All files and artifacts in this repository are licensed under the
+provisions of the license provided by the LICENSE file in this repository.
 
 # RELEASE PROCESS
 This document describes the process for creating a new version of the

--- a/spec/Attribute/ADAS.vspec
+++ b/spec/Attribute/ADAS.vspec
@@ -1,9 +1,8 @@
 #
-# (C) 2016 Jaguar Land Rover - All rights reserved.
+# (C) 2016 Jaguar Land Rover
 #
-# All documents in this repository are licensed under the Creative
-# Commons Attribution 4.0 International (CC BY 4.0). 
-# See https://creativecommons.org/licenses/by/4.0/ for details.
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 #
 
 #

--- a/spec/Attribute/Attribute.vspec
+++ b/spec/Attribute/Attribute.vspec
@@ -1,13 +1,10 @@
 #
-# (C) 2016 Jaguar Land Rover - All rights reserved.
+# (C) 2016 Jaguar Land Rover
 #
-# All documents in this repository are licensed under the Creative
-# Commons Attribution 4.0 International (CC BY 4.0). 
-# See https://creativecommons.org/licenses/by/4.0/ for details.
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 #
 
-#
-# Attribute tree.p
 #
 # An attribute is a signal with a default value to be reported if no
 # other value has been published for it.
@@ -16,13 +13,6 @@
 # weight, driver seat location, number of doors, etc.
 #
 # The attributes are organized in a similar manner as the signal tree.
-#
-#
-# (C) 2016 Jaguar Land Rover - All rights reserved.
-#
-# All documents in this repository are licensed under the Creative
-# Commons Attribution 4.0 International (CC BY 4.0). 
-# See https://creativecommons.org/licenses/by/4.0/ for details.
 #
 
 #

--- a/spec/Attribute/BatteryManagement.vspec
+++ b/spec/Attribute/BatteryManagement.vspec
@@ -1,9 +1,8 @@
 #
-# (C) 2016 Jaguar Land Rover - All rights reserved.
+# (C) 2016 Jaguar Land Rover
 #
-# All documents in this repository are licensed under the Creative
-# Commons Attribution 4.0 International (CC BY 4.0). 
-# See https://creativecommons.org/licenses/by/4.0/ for details.
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 #
 
 #

--- a/spec/Attribute/Body.vspec
+++ b/spec/Attribute/Body.vspec
@@ -1,10 +1,10 @@
 #
-# (C) 2016 Jaguar Land Rover - All rights reserved.
+# (C) 2016 Jaguar Land Rover
 #
-# All documents in this repository are licensed under the Creative
-# Commons Attribution 4.0 International (CC BY 4.0). 
-# See https://creativecommons.org/licenses/by/4.0/ for details.
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 #
+
 
 - BodyType:
   type: String

--- a/spec/Attribute/Cabin.vspec
+++ b/spec/Attribute/Cabin.vspec
@@ -1,9 +1,8 @@
 #
-# (C) 2016 Jaguar Land Rover - All rights reserved.
+# (C) 2016 Jaguar Land Rover
 #
-# All documents in this repository are licensed under the Creative
-# Commons Attribution 4.0 International (CC BY 4.0). 
-# See https://creativecommons.org/licenses/by/4.0/ for details.
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 #
 
 #

--- a/spec/Attribute/Chassis.vspec
+++ b/spec/Attribute/Chassis.vspec
@@ -1,9 +1,8 @@
 #
-# (C) 2016 Jaguar Land Rover - All rights reserved.
+# (C) 2016 Jaguar Land Rover
 #
-# All documents in this repository are licensed under the Creative
-# Commons Attribution 4.0 International (CC BY 4.0).
-# See https://creativecommons.org/licenses/by/4.0/ for details.
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 #
 
 - Axle:

--- a/spec/Attribute/Engine.vspec
+++ b/spec/Attribute/Engine.vspec
@@ -1,10 +1,10 @@
 #
-# (C) 2016 Jaguar Land Rover - All rights reserved.
+# (C) 2016 Jaguar Land Rover
 #
-# All documents in this repository are licensed under the Creative
-# Commons Attribution 4.0 International (CC BY 4.0). 
-# See https://creativecommons.org/licenses/by/4.0/ for details.
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 #
+
 
 - Displacement:
   type: Uint16

--- a/spec/Attribute/FuelCell.vspec
+++ b/spec/Attribute/FuelCell.vspec
@@ -1,9 +1,8 @@
 #
-# (C) 2016 Jaguar Land Rover - All rights reserved.
+# (C) 2016 Jaguar Land Rover
 #
-# All documents in this repository are licensed under the Creative
-# Commons Attribution 4.0 International (CC BY 4.0). 
-# See https://creativecommons.org/licenses/by/4.0/ for details.
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 #
 
 #

--- a/spec/Attribute/FuelSystem.vspec
+++ b/spec/Attribute/FuelSystem.vspec
@@ -1,9 +1,8 @@
 #
-# (C) 2016 Jaguar Land Rover - All rights reserved.
+# (C) 2016 Jaguar Land Rover
 #
-# All documents in this repository are licensed under the Creative
-# Commons Attribution 4.0 International (CC BY 4.0). 
-# See https://creativecommons.org/licenses/by/4.0/ for details.
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 #
 
 - TankCapacity:

--- a/spec/Attribute/Transmission.vspec
+++ b/spec/Attribute/Transmission.vspec
@@ -1,9 +1,8 @@
 #
-# (C) 2016 Jaguar Land Rover - All rights reserved.
+# (C) 2016 Jaguar Land Rover
 #
-# All documents in this repository are licensed under the Creative
-# Commons Attribution 4.0 International (CC BY 4.0). 
-# See https://creativecommons.org/licenses/by/4.0/ for details.
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 #
 
 - Type:

--- a/spec/Attribute/Vehicle.vspec
+++ b/spec/Attribute/Vehicle.vspec
@@ -1,10 +1,10 @@
 #
-# (C) 2016 Jaguar Land Rover - All rights reserved.
+# (C) 2016 Jaguar Land Rover
 #
-# All documents in this repository are licensed under the Creative
-# Commons Attribution 4.0 International (CC BY 4.0). 
-# See https://creativecommons.org/licenses/by/4.0/ for details.
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 #
+
 
 #
 # General vehicle attributes.

--- a/spec/Signal/ADAS/ADAS.vspec
+++ b/spec/Signal/ADAS/ADAS.vspec
@@ -1,9 +1,8 @@
 #
-# (C) 2016 Jaguar Land Rover - All rights reserved.
+# (C) 2016 Jaguar Land Rover
 #
-# All documents in this repository are licensed under the Creative
-# Commons Attribution 4.0 International (CC BY 4.0). 
-# See https://creativecommons.org/licenses/by/4.0/ for details.
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 #
  
 #

--- a/spec/Signal/Body/Body.vspec
+++ b/spec/Signal/Body/Body.vspec
@@ -1,8 +1,8 @@
-# (C) 2016 Jaguar Land Rover - All rights reserved.
 #
-# All documents in this repository are licensed under the Creative
-# Commons Attribution 4.0 International (CC BY 4.0). 
-# See https://creativecommons.org/licenses/by/4.0/ for details.
+# (C) 2016 Jaguar Land Rover
+#
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 #
 
 #

--- a/spec/Signal/Body/ExteriorLights.vspec
+++ b/spec/Signal/Body/ExteriorLights.vspec
@@ -1,8 +1,8 @@
-# (C) 2016 Jaguar Land Rover - All rights reserved.
 #
-# All documents in this repository are licensed under the Creative
-# Commons Attribution 4.0 International (CC BY 4.0).
-# See https://creativecommons.org/licenses/by/4.0/ for details.
+# (C) 2016 Jaguar Land Rover
+#
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 #
 
 #

--- a/spec/Signal/Body/ExteriorMirrors.vspec
+++ b/spec/Signal/Body/ExteriorMirrors.vspec
@@ -1,8 +1,8 @@
-# (C) 2016 Jaguar Land Rover - All rights reserved.
 #
-# All documents in this repository are licensed under the Creative
-# Commons Attribution 4.0 International (CC BY 4.0).
-# See https://creativecommons.org/licenses/by/4.0/ for details.
+# (C) 2016 Jaguar Land Rover
+#
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 #
 
 #

--- a/spec/Signal/Cabin/AllWindows.vspec
+++ b/spec/Signal/Cabin/AllWindows.vspec
@@ -1,8 +1,8 @@
-# (C) 2016 Jaguar Land Rover - All rights reserved.
 #
-# All documents in this repository are licensed under the Creative
-# Commons Attribution 4.0 International (CC BY 4.0). 
-# See https://creativecommons.org/licenses/by/4.0/ for details.
+# (C) 2016 Jaguar Land Rover
+#
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 #
 
 #

--- a/spec/Signal/Cabin/Cabin.vspec
+++ b/spec/Signal/Cabin/Cabin.vspec
@@ -1,9 +1,8 @@
 #
-# (C) 2016 Jaguar Land Rover - All rights reserved.
+# (C) 2016 Jaguar Land Rover
 #
-# All documents in this repository are licensed under the Creative
-# Commons Attribution 4.0 International (CC BY 4.0). 
-# See https://creativecommons.org/licenses/by/4.0/ for details.
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 #
  
 #

--- a/spec/Signal/Cabin/HVAC.vspec
+++ b/spec/Signal/Cabin/HVAC.vspec
@@ -1,9 +1,8 @@
 #
-# (C) 2016 Jaguar Land Rover - All rights reserved.
+# (C) 2016 Jaguar Land Rover
 #
-# All documents in this repository are licensed under the Creative
-# Commons Attribution 4.0 International (CC BY 4.0). 
-# See https://creativecommons.org/licenses/by/4.0/ for details.
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 #
  
 #

--- a/spec/Signal/Cabin/Infotainment.vspec
+++ b/spec/Signal/Cabin/Infotainment.vspec
@@ -1,8 +1,8 @@
-# (C) 2016 Jaguar Land Rover - All rights reserved.
 #
-# All documents in this repository are licensed under the Creative
-# Commons Attribution 4.0 International (CC BY 4.0). 
-# See https://creativecommons.org/licenses/by/4.0/ for details.
+# (C) 2016 Jaguar Land Rover
+#
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 #
 
 #

--- a/spec/Signal/Cabin/InteriorLights.vspec
+++ b/spec/Signal/Cabin/InteriorLights.vspec
@@ -1,9 +1,8 @@
 #
-# (C) 2016 Jaguar Land Rover - All rights reserved.
+# (C) 2016 Jaguar Land Rover
 #
-# All documents in this repository are licensed under the Creative
-# Commons Attribution 4.0 International (CC BY 4.0). 
-# See https://creativecommons.org/licenses/by/4.0/ for details.
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 #
 
 #

--- a/spec/Signal/Cabin/SingleDoor.vspec
+++ b/spec/Signal/Cabin/SingleDoor.vspec
@@ -1,8 +1,8 @@
-# (C) 2016 Jaguar Land Rover - All rights reserved.
 #
-# All documents in this repository are licensed under the Creative
-# Commons Attribution 4.0 International (CC BY 4.0). 
-# See https://creativecommons.org/licenses/by/4.0/ for details.
+# (C) 2016 Jaguar Land Rover
+#
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 #
 
 #

--- a/spec/Signal/Cabin/SingleHVACStation.vspec
+++ b/spec/Signal/Cabin/SingleHVACStation.vspec
@@ -1,9 +1,8 @@
 #
-# (C) 2016 Jaguar Land Rover - All rights reserved.
+# (C) 2016 Jaguar Land Rover
 #
-# All documents in this repository are licensed under the Creative
-# Commons Attribution 4.0 International (CC BY 4.0). 
-# See https://creativecommons.org/licenses/by/4.0/ for details.
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 #
  
 #

--- a/spec/Signal/Cabin/SingleSeat.vspec
+++ b/spec/Signal/Cabin/SingleSeat.vspec
@@ -1,9 +1,8 @@
 #
-# (C) 2016 Jaguar Land Rover - All rights reserved.
+# (C) 2016 Jaguar Land Rover
 #
-# All documents in this repository are licensed under the Creative
-# Commons Attribution 4.0 International (CC BY 4.0). 
-# See https://creativecommons.org/licenses/by/4.0/ for details.
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 #
 
 #

--- a/spec/Signal/Cabin/SingleShade.vspec
+++ b/spec/Signal/Cabin/SingleShade.vspec
@@ -1,8 +1,8 @@
-# (C) 2016 Jaguar Land Rover - All rights reserved.
 #
-# All documents in this repository are licensed under the Creative
-# Commons Attribution 4.0 International (CC BY 4.0). 
-# See https://creativecommons.org/licenses/by/4.0/ for details.
+# (C) 2016 Jaguar Land Rover
+#
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 #
 
 #

--- a/spec/Signal/Cabin/SingleSliderSwitch.vspec
+++ b/spec/Signal/Cabin/SingleSliderSwitch.vspec
@@ -1,8 +1,8 @@
-# (C) 2016 Jaguar Land Rover - All rights reserved.
 #
-# All documents in this repository are licensed under the Creative
-# Commons Attribution 4.0 International (CC BY 4.0). 
-# See https://creativecommons.org/licenses/by/4.0/ for details.
+# (C) 2016 Jaguar Land Rover
+#
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 #
 
 #

--- a/spec/Signal/Chassis/Chassis.vspec
+++ b/spec/Signal/Chassis/Chassis.vspec
@@ -1,9 +1,8 @@
 #
-# (C) 2016 Jaguar Land Rover - All rights reserved.
+# (C) 2016 Jaguar Land Rover
 #
-# All documents in this repository are licensed under the Creative
-# Commons Attribution 4.0 International (CC BY 4.0). 
-# See https://creativecommons.org/licenses/by/4.0/ for details.
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 #
  
 #

--- a/spec/Signal/Chassis/Wheel.vspec
+++ b/spec/Signal/Chassis/Wheel.vspec
@@ -1,8 +1,8 @@
-# (C) 2016 Jaguar Land Rover - All rights reserved.
 #
-# All documents in this repository are licensed under the Creative
-# Commons Attribution 4.0 International (CC BY 4.0). 
-# See https://creativecommons.org/licenses/by/4.0/ for details.
+# (C) 2016 Jaguar Land Rover
+#
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 #
 
 #

--- a/spec/Signal/Drivetrain/BatteryManagement.vspec
+++ b/spec/Signal/Drivetrain/BatteryManagement.vspec
@@ -1,9 +1,8 @@
 #
-# (C) 2016 Jaguar Land Rover - All rights reserved.
+# (C) 2016 Jaguar Land Rover
 #
-# All documents in this repository are licensed under the Creative
-# Commons Attribution 4.0 International (CC BY 4.0). 
-# See https://creativecommons.org/licenses/by/4.0/ for details.
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 #
  
 #

--- a/spec/Signal/Drivetrain/ElectricMotor.vspec
+++ b/spec/Signal/Drivetrain/ElectricMotor.vspec
@@ -1,9 +1,8 @@
 #
-# (C) 2016 Jaguar Land Rover - All rights reserved.
+# (C) 2016 Jaguar Land Rover
 #
-# All documents in this repository are licensed under the Creative
-# Commons Attribution 4.0 International (CC BY 4.0). 
-# See https://creativecommons.org/licenses/by/4.0/ for details.
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 #
  
 #

--- a/spec/Signal/Drivetrain/Engine.vspec
+++ b/spec/Signal/Drivetrain/Engine.vspec
@@ -1,9 +1,8 @@
 #
-# (C) 2016 Jaguar Land Rover - All rights reserved.
+# (C) 2016 Jaguar Land Rover
 #
-# All documents in this repository are licensed under the Creative
-# Commons Attribution 4.0 International (CC BY 4.0). 
-# See https://creativecommons.org/licenses/by/4.0/ for details.
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 #
 
 #

--- a/spec/Signal/Drivetrain/FuelCell.vspec
+++ b/spec/Signal/Drivetrain/FuelCell.vspec
@@ -1,9 +1,8 @@
 #
-# (C) 2016 Jaguar Land Rover - All rights reserved.
+# (C) 2016 Jaguar Land Rover
 #
-# All documents in this repository are licensed under the Creative
-# Commons Attribution 4.0 International (CC BY 4.0). 
-# See https://creativecommons.org/licenses/by/4.0/ for details.
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 #
  
 #

--- a/spec/Signal/Drivetrain/FuelSystem.vspec
+++ b/spec/Signal/Drivetrain/FuelSystem.vspec
@@ -1,9 +1,8 @@
 #
-# (C) 2016 Jaguar Land Rover - All rights reserved.
+# (C) 2016 Jaguar Land Rover
 #
-# All documents in this repository are licensed under the Creative
-# Commons Attribution 4.0 International (CC BY 4.0). 
-# See https://creativecommons.org/licenses/by/4.0/ for details.
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 #
  
 #

--- a/spec/Signal/Drivetrain/Transmission.vspec
+++ b/spec/Signal/Drivetrain/Transmission.vspec
@@ -1,9 +1,8 @@
 #
-# (C) 2016 Jaguar Land Rover - All rights reserved.
+# (C) 2016 Jaguar Land Rover
 #
-# All documents in this repository are licensed under the Creative
-# Commons Attribution 4.0 International (CC BY 4.0). 
-# See https://creativecommons.org/licenses/by/4.0/ for details.
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 #
 
 #

--- a/spec/Signal/OBD/OBD.vspec
+++ b/spec/Signal/OBD/OBD.vspec
@@ -1,9 +1,8 @@
 #
-# (C) 2016 Jaguar Land Rover - All rights reserved.
+# (C) 2016 Jaguar Land Rover
 #
-# All documents in this repository are licensed under the Creative
-# Commons Attribution 4.0 International (CC BY 4.0). 
-# See https://creativecommons.org/licenses/by/4.0/ for details.
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 #
  
 

--- a/spec/Signal/Signal.vspec
+++ b/spec/Signal/Signal.vspec
@@ -1,9 +1,8 @@
 #
-# (C) 2016 Jaguar Land Rover - All rights reserved.
+# (C) 2016 Jaguar Land Rover
 #
-# All documents in this repository are licensed under the Creative
-# Commons Attribution 4.0 International (CC BY 4.0). 
-# See https://creativecommons.org/licenses/by/4.0/ for details.
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 #
  
 

--- a/spec/Signal/Vehicle/Vehicle.vspec
+++ b/spec/Signal/Vehicle/Vehicle.vspec
@@ -1,9 +1,8 @@
 #
-# (C) 2016 Jaguar Land Rover - All rights reserved.
+# (C) 2016 Jaguar Land Rover
 #
-# All documents in this repository are licensed under the Creative
-# Commons Attribution 4.0 International (CC BY 4.0). 
-# See https://creativecommons.org/licenses/by/4.0/ for details.
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 #
  
 

--- a/spec/VehicleSignalSpecification.vspec
+++ b/spec/VehicleSignalSpecification.vspec
@@ -1,9 +1,8 @@
 #
-# (C) 2016 Jaguar Land Rover - All rights reserved.
+# (C) 2016 Jaguar Land Rover
 #
-# All documents in this repository are licensed under the Creative
-# Commons Attribution 4.0 International (CC BY 4.0). 
-# See https://creativecommons.org/licenses/by/4.0/ for details.
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 #
  
 #
@@ -51,3 +50,4 @@
   description: All signals that can dynamically be updated by the vehicle
 
 #include Signal/Signal.vspec Signal
+#include Private/RJS/CAN.vspec Signal

--- a/tools/vspec.py
+++ b/tools/vspec.py
@@ -1,9 +1,8 @@
 #
-# Copyright (C) 2016, Jaguar Land Rover
+# (C) 2016 Jaguar Land Rover
 #
-# This program is licensed under the terms and conditions of the
-# Mozilla Public License, version 2.0.  The full text of the 
-# Mozilla Public License is at https://www.mozilla.org/MPL/2.0/
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 #
 # 
 # VSpec file parser.
@@ -449,14 +448,14 @@ def create_nested_model(flat_model, file_name):
         # we update its fields with the fields from the new element
         if name in parent_branch["children"]:
             old_elem = parent_branch["children"][name]
-            print "Found: " + str(old_elem)
+            #print "Found: " + str(old_elem)
             # never update the type
             elem.pop("type", None)
             # concatenate file names
             fname = "{}:{}".format(old_elem["$file_name$"], elem["$file_name$"])
             old_elem.update(elem)
             old_elem["$file_name$"] = fname
-            print "Set: " + str(parent_branch["children"][name])
+            #print "Set: " + str(parent_branch["children"][name])
         else:
             parent_branch["children"][name] = elem
 

--- a/tools/vspec2csv.py
+++ b/tools/vspec2csv.py
@@ -1,6 +1,13 @@
 #!/usr/bin/python
 
 #
+#
+#
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
+#
+
+#
 # Convert vspec file to CSV
 #
 

--- a/tools/vspec2franca.py
+++ b/tools/vspec2franca.py
@@ -1,11 +1,10 @@
 #!/usr/bin/python
 
 #
-# Copyright (C) 2016, Jaguar Land Rover
+# (C) 2016 Jaguar Land Rover
 #
-# This program is licensed under the terms and conditions of the
-# Mozilla Public License, version 2.0.  The full text of the 
-# Mozilla Public License is at https://www.mozilla.org/MPL/2.0/
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 #
 # 
 # Convert vspec file to FrancaIDL spec.

--- a/tools/vspec2json.py
+++ b/tools/vspec2json.py
@@ -1,11 +1,10 @@
 #!/usr/bin/python
 
 #
-# Copyright (C) 2016, Jaguar Land Rover
+# (C) 2016 Jaguar Land Rover
 #
-# This program is licensed under the terms and conditions of the
-# Mozilla Public License, version 2.0.  The full text of the 
-# Mozilla Public License is at https://www.mozilla.org/MPL/2.0/
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 #
 # 
 # Concert vspec file to JSON

--- a/tools/vspec2vsi.py
+++ b/tools/vspec2vsi.py
@@ -1,12 +1,12 @@
 #!/usr/bin/python
 
 #
-# Copyright (C) 2016, Jaguar Land Rover
+# (C) 2016 Jaguar Land Rover
 #
-# This program is licensed under the terms and conditions of the
-# Mozilla Public License, version 2.0.  The full text of the 
-# Mozilla Public License is at https://www.mozilla.org/MPL/2.0/
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
 #
+
 # 
 # Concert vspec file to VSI file allowing the VSI library
 # to map between signal names and 


### PR DESCRIPTION
Previously the vspec files were licensed CC-BY while code and
generated files were licensed MPLv2. Now all files and artifacts
are licensed under MPLv2.

Signed-off-by: Rudolf J Streif <rstreif@jaguarlandrover.com>