### PR TITLE
Changed gear data type from Uint8 to Int8

### DIFF
--- a/spec/Signal/Drivetrain/Transmission.vspec
+++ b/spec/Signal/Drivetrain/Transmission.vspec
@@ -27,7 +27,7 @@
 # Current gear
 #
 - Gear:
-  type: UInt8
+  type: Int8
   min: -1
   max: 16
   description: Current gear. 0=Neutral. -1=Reverse


### PR DESCRIPTION
The previous data type was incorrect because a negative value of
-1 means the reverse gear.

Signed-off-by: Rudolf J Streif <rstreif@jaguarlandrover.com>