### PR TITLE
Fixed typo

### DIFF
--- a/spec/Attribute/Cabin.vspec
+++ b/spec/Attribute/Cabin.vspec
@@ -55,7 +55,7 @@
 - Seat.Row2PosCount:
   type: Uint8
   value: 0
-  description: Number of seats across row 3
+  description: Number of seats across row 2
 
 - Seat.Row3PosCount:
   type: Uint8


### PR DESCRIPTION
The comment should have read 2 instead of 3.

Signed-off-by: Rudolf J Streif <rstreif@jaguarlandrover.com>