### PR TITLE
README: Fix link to raw JSON file for JSON editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@ the ```VERSION``` file.
 
 A web-based JSON viewer can be used to view the current version.
 
-Click **[here](http://www.jsoneditoronline.org/?url=https://raw.githubusercontent.com/GENIVI/vehicle_signal_specification/develop/vss_rel_1.json)**
-
+Click **[here](https://jsoneditoronline.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2FGENIVI%2Fvehicle_signal_specification%2Fdevelop%2Fvss_rel_1.0.json)**
 
 # CREATE JSON VEHICLE SIGNAL SPECIFICATION
 


### PR DESCRIPTION
Apparently the online JSON editor requires some escaping of the URL to work properly.  
Let's merge it... (I actually considered just commiting it right away to develop branch :)