### PR TITLE
Specify safe YAML loader, which avoids warning

### DIFF
--- a/tools/vspec.py
+++ b/tools/vspec.py
@@ -144,7 +144,7 @@ class SignalUUID_DB:
         if os.path.isfile(id_file_name):
             with open (self.id_file_name, "r") as fp:
                 text = fp.read()
-                self.db = yaml.load(text)
+                self.db = yaml.load(text, Loader=yaml.SafeLoader)
                 if not self.db:
                     self.db = {}
                 fp.close()


### PR DESCRIPTION
This change deals with the warning that was printed before.
(read link for more info):

   YAMLLoadWarning: calling yaml.load() without Loader=... is
   deprecated, as the default Loader is unsafe. Please read
   https://msg.pyyaml.org/load for full details.

Signed-off-by: Gunnar Andersson <gandersson@genivi.org>