### PR TITLE
make path parameter const for vss_get_signal_by_path()

### DIFF
--- a/tools/vspec2c/vehicle_signal_specification.c
+++ b/tools/vspec2c/vehicle_signal_specification.c
@@ -74,7 +74,7 @@ const uint32_t vss_get_signature(void)
     return vss_signal[0].signature;
 }
 
-int vss_get_signal_by_path(char* path,
+int vss_get_signal_by_path(const char* path,
                             vss_signal_t ** result)
 {
     vss_signal_t * cur_signal = &vss_signal[0]; // Start at root.

--- a/tools/vspec2c/vehicle_signal_specification.h
+++ b/tools/vspec2c/vehicle_signal_specification.h
@@ -173,7 +173,7 @@ extern vss_signal_t* vss_get_signal_by_index(int index);
 // Locate a signal by its path.
 // Path is in the format "Branch.Branch.[...].Signal.
 // If
-extern int vss_get_signal_by_path(char* path,
+extern int vss_get_signal_by_path(const char* path,
                                    vss_signal_t ** result);
 
 const char* vss_element_type_string(vss_element_type_e elem_type);


### PR DESCRIPTION
This function can accept a const char *, so it should.  

Solves the problem when the compiler only uses the const overload of std::string::data() even though the non-const version exists.