### PR TITLE
Force use of Python3

### DIFF
--- a/tools/vspec2franca.py
+++ b/tools/vspec2franca.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 #
 # (C) 2016 Jaguar Land Rover

--- a/tools/vspec2json.py
+++ b/tools/vspec2json.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 #
 # (C) 2016 Jaguar Land Rover


### PR DESCRIPTION
Tested on a fresh Ubuntu 18.04 box. 
Failed before update due to python being mapped to python2.
Succeeded after update since python3 is explicitly specified.