### PR TITLE
Versioning: Added VSS Versions to VSS tree

### DIFF
--- a/spec/Vehicle/Vehicle.vspec
+++ b/spec/Vehicle/Vehicle.vspec
@@ -12,6 +12,29 @@
 #
 
 #
+# VSS Versioning information
+#
+
+- VersionVSS:
+  type: branch
+  description: Supported Version of VSS
+
+- VersionVSS.Major:
+  datatype: uint8
+  type: attribute
+  description: Supported Version of VSS - Major version
+
+- VersionVSS.Minor:
+  datatype: uint8
+  type: attribute
+  description: Supported Version of VSS - Minor version
+
+- VersionVSS.Patch:
+  datatype: uint8
+  type: attribute
+  description: Supported Version of VSS - Patch version
+
+#
 # Vehicle identification attributes.
 #
 

--- a/spec/Vehicle/Vehicle.vspec
+++ b/spec/Vehicle/Vehicle.vspec
@@ -20,19 +20,24 @@
   description: Supported Version of VSS
 
 - VersionVSS.Major:
-  datatype: uint8
+  datatype: uint32
   type: attribute
   description: Supported Version of VSS - Major version
 
 - VersionVSS.Minor:
-  datatype: uint8
+  datatype: uint32
   type: attribute
   description: Supported Version of VSS - Minor version
 
 - VersionVSS.Patch:
-  datatype: uint8
+  datatype: uint32
   type: attribute
   description: Supported Version of VSS - Patch version
+
+- VersionVSS.Label:
+  datatype: string
+  type: attribute
+  description: Label to further describe the version
 
 #
 # Vehicle identification attributes.


### PR DESCRIPTION
As the concept of the tree changes over time, it is important for the
client to know, which version it's expecting. Split it into Major,
Minor, Patch to avoid unnecessary string parsing.

Fixes: #132