### PR TITLE
Cleaned up inconsistent unit specification

### DIFF
--- a/spec/OBD/OBD.vspec
+++ b/spec/OBD/OBD.vspec
@@ -311,7 +311,7 @@
 - DistanceWithMIL:
   datatype: uint32
   type: sensor
-  unit: kilometer
+  unit: km
   description: PID 21 - Distance traveled with MIL on
 
 - FuelRailPressureVac:

--- a/spec/Vehicle/Vehicle.vspec
+++ b/spec/Vehicle/Vehicle.vspec
@@ -274,13 +274,13 @@
 - accelerationTime:
   datatype: int16
   type: attribute
-  unit: sec
+  unit: s
   description: The time needed to accelerate the vehicle from a given start velocity to a given target velocity.
 
 - cargoVolume:
   datatype: int16
   type: attribute
-  unit: litres
+  unit: l
   description: The available volume for cargo or luggage. For automobiles, this is usually the trunk volume.
   min: 0
   max: 100


### PR DESCRIPTION
Found some inconsitencies in the unit specifications (e.g., unit: kilometer instead of unit: km). This PR cleans that up