### PR TITLE
Changing ChargingInlet > ChargingPort

### DIFF
--- a/spec/Body/Body.vspec
+++ b/spec/Body/Body.vspec
@@ -151,13 +151,13 @@
 # Charging Inlet definition
 ##
 
-- ChargingInlet:
+- ChargingPort:
   type: branch
-  description: Collects Information about the charging inlet
+  description: Collects Information about the charging port
 
-- ChargingInlet.Type:
+- ChargingPort.Type:
   datatype: string
   type: attribute
   enum: [ "unknown", "Not_Fitted", "AC_Type_1", "AC_Type_2", "AC_GBT", "AC_DC_Type_1_Combo", "AC_DC_Type_2_Combo", "DC_GBT", "DC_Chademo" ]
   default: "unknown"
-  description: Indicates the primary charging inlet type fitted to the vehicle
+  description: Indicates the primary charging type fitted to the vehicle


### PR DESCRIPTION
ChargingInlet is leading to the idea, that it's unidirectional.
That might not be true for all ports. So, renaming would be needed.

@SebastianSchildt

Fixes: #160