### PR TITLE
Add List of DTCs to OBD branch

### DIFF
--- a/spec/OBD/OBD.vspec
+++ b/spec/OBD/OBD.vspec
@@ -1,4 +1,5 @@
 #
+# (C) 2020 Robert Bosch GmbH
 # (C) 2018 Volvo Cars
 # (C) 2016 Jaguar Land Rover
 #
@@ -42,6 +43,11 @@
   type: sensor
   enum: [ "spark", "compression" ]
   description: Type of the ignition for ICE - spark = spark plug ignition, compression = self-igniting (Diesel engines)
+
+- DTCList:
+  datatype: string[]
+  type: sensor
+  description: List of cuurently active DTCs formatted according OBD II standard ([P|C|B|U]XXXXX )
 
 - FreezeDTC:
   datatype: string


### PR DESCRIPTION
The OBD branch was missing the list of DTCs itself (even so DTCCount, DistanceSinceDTCClear etc. was already there).

This is related to #165 

For the OBD branch we should follow OBD semantics for DTCs, and not trying to be clever about presenting this information. Consequently I used an array of strings, I do however think not all our tooling can deal with the array definition yet. I get an error on vspec2c:
``` 
./vss-tools/vspec2c.py -i:./spec/VehicleSignalSpecification.id -I ./spec ./spec/VehicleSignalSpecification.vspec vss_rel_$(cat VERSION).h vss_rel_$(cat VERSION)_macro.h
Illegal data type: 'string[]'
Signal: Vehicle_OBD_DTCList
Try: int8 uint8 int16 uint16 int32 uint32 int64 uint64
     float double string boolean stream
make: *** [Makefile:30: c] Error 255
```
Can/should/will we repair that? Who knows how to?