### PR TITLE
vss-tools: Bump submodule

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 git:
   submodules: true
 
-language: python
+language: python3
 
 env:
   global:
@@ -13,8 +13,10 @@ env:
 install:
   - curl -LO https://github.com/gohugoio/hugo/releases/download/v${HUGO_VER}/hugo_${HUGO_VER}_Linux-64bit.deb
   - sudo dpkg -i hugo_${HUGO_VER}_Linux-64bit.deb
-  - pip install pyyaml
-  - cd ${TOOLS_DIR} && python setup.py -q install && cd ..
+  - cd ${TOOLS_DIR} 
+  - pip3 install -r requirements.txt
+  - python3 setup.py -q install
+  - cd ..
 
 script:
   - make clean json deploy


### PR DESCRIPTION
New PR to bump submodule to latest master of vss-tools.  According to travis check on vss-tools it seems to build OK (that is not yet merged to vss-tools master, but it seems to work:  https://travis-ci.org/github/gunnarx/vss-tools/builds/723152253)
We don't really need to merge it before updating, because it doesn't affect the Travis check on **this** repo.

The commit also includes a shortlog of the changes as follows:  (A good practice we may want to adopt)
----------

  14efa2e Changed N.m to Nm
  67b13c6 Bugfix: Add previously removed method
  b6814db Typo in Enum Handling for UInt64 fixed
  4497a47 Added typesafe parsing using anytree, including tests and ReadMe.MD Migrated csv parser for demonstration purposes
  55ae597 Merge pull request #4 from magnusfeuer/master
  7039c86 Fixes issue https://github.com/GENIVI/vss-tools/pull/4#issuecomment-636300056
  51757b5 cnative tool refactoring.
  7fbe9ce Adding Licence file
  416da82 Introduced dictionary-parsing vspec.py.

Signed-off-by: Gunnar Andersson <gandersson@genivi.org>