### PR TITLE
Remove `value`/`default` inconsistency

### DIFF
--- a/docs-gen/content/rule_set/data_entry/attributes.md
+++ b/docs-gen/content/rule_set/data_entry/attributes.md
@@ -5,7 +5,7 @@ weight: 5
 ---
 
 An attribute is a signal with a default value, specified by
-its ```value``` member.
+its ```default``` member.
 
 The value set for an attribute by a vspec file can be read by a
 consumer without the need of having the value sent out by a

--- a/spec/Cabin/Cabin.vspec
+++ b/spec/Cabin/Cabin.vspec
@@ -132,7 +132,7 @@
 - DoorCount:
   datatype: uint8
   type: attribute
-  value: 0
+  default: 0
   description: Number of doors in vehicle
 
 
@@ -161,20 +161,20 @@
 - DriverPosition:
   datatype: uint8
   type: attribute
-  value: 0
+  default: 0
   description: The position of the driver seat in row 1. (1-5)
 
 - SeatRowCount:
   datatype: uint8
   type: attribute
-  value: 0
+  default: 0
   description: Number of seat rows in vehicle
 
 - SeatPosCount:
   instances: Row[1,4]
   datatype: uint8
   type: attribute
-  value: 0
+  default: 0
   description: Number of seats across each row from the front to the rear
 
 

--- a/spec/Chassis/Chassis.vspec
+++ b/spec/Chassis/Chassis.vspec
@@ -16,56 +16,56 @@
 - CurbWeight:
   datatype: uint16
   type: attribute
-  value: 0
+  default: 0
   unit: kg
   description: Vehicle curb weight, in kg, including all liquids and full tank of fuel, but no cargo or passengers.
 
 - GrossWeight:
   datatype: uint16
   type: attribute
-  value: 0
+  default: 0
   unit: kg
   description: Curb weight of vehicle, including all liquids and full tank of fuel and full load of cargo and passengers.
 
 - TowWeight:
   datatype: uint16
   type: attribute
-  value: 0
+  default: 0
   unit: kg
   description: Maximum weight, in kilos, of trailer.
 
 - Length:
   datatype: uint16
   type: attribute
-  value: 0
+  default: 0
   unit: mm
   description: Overall vehicle length, in mm.
 
 - Height:
   datatype: uint16
   type: attribute
-  value: 0
+  default: 0
   unit: mm
   description: Overall vehicle height, in mm.
 
 - Width:
   datatype: uint16
   type: attribute
-  value: 0
+  default: 0
   unit: mm
   description: Overall vehicle width, in mm.
 
 - Wheelbase:
   datatype: uint16
   type: attribute
-  value: 0
+  default: 0
   unit: mm
   description: Overall wheel base, in mm.
 
 - Track:
   datatype: uint16
   type: attribute
-  value: 0
+  default: 0
   unit: mm
   description: Overall wheel tracking, in mm.
 
@@ -81,7 +81,7 @@
 - AxleCount:
   datatype: uint8
   type: attribute
-  value: 2
+  default: 2
   description: Number of axles on the vehicle
 
 
@@ -178,7 +178,7 @@
 - SteeringWheel.Position:
   datatype: string
   type: attribute
-  value: front_left
+  default: front_left
   enum: ["front_left", "front_right"]
   description: Position of the steering wheel on the left or right side of the vehicle.
 

--- a/spec/Powertrain/FuelSystem.vspec
+++ b/spec/Powertrain/FuelSystem.vspec
@@ -27,7 +27,7 @@
 - TankCapacity:
   datatype: uint16
   type: attribute
-  value: 0
+  default: 0
   unit: l
   description: Capacity of the fuel tank in liters
 

--- a/spec/Powertrain/Transmission.vspec
+++ b/spec/Powertrain/Transmission.vspec
@@ -17,21 +17,21 @@
   datatype: string
   type: attribute
   enum: [ "unknown", "sequential", "H", "automatic", "DSG", "CVT" ]
-  value: "unknown"
+  default: "unknown"
   description: Transmission type.
 
 
 - GearCount:
   datatype: uint8
   type: attribute
-  value: 0
+  default: 0
   description: Number of forward gears in the transmission. -1 = CVT.
 
 - DriveType:
   datatype: string
   type: attribute
   enum: [ "unknown", "forward wheel drive", "rear wheel drive", "all wheel drive" ]
-  value: "unknown"
+  default: "unknown"
   description: Drive type.
 
 #


### PR DESCRIPTION
In the spec value and default were used exchangeably.
Used `default` throughout the spec-files.

Fixes: #198