### PR TITLE
Fix/fix units again

### DIFF
--- a/docs-gen/content/rule_set/data_entry/data_types.md
+++ b/docs-gen/content/rule_set/data_entry/data_types.md
@@ -10,19 +10,19 @@ Each [data entry](/vehicle_signal_specification/rule_set/data_entry) specifies a
 
 Name       | Type                       | Min  | Max
 :----------|:---------------------------|:-----|:---
-UInt8      | unsigned 8-bit integer     | 0    | 255
-Int8       | signed 8-bit integer       | -128 | 127
-UInt16     | unsigned 16-bit integer    |  0   | 65535
-Int16      | signed 16-bit integer      | -32768 | 32767
-UInt32     | unsigned 32-bit integer    | 0 | 4294967295
-Int32      | signed 32-bit integer      | -2147483648 | 2147483647
-UInt64     | unsigned 64-bit integer    | 0    | 2^64
-Int64      | signed 64-bit integer      | -2^63 | 2^63 - 1
-Boolean    | boolean value              | 0/false | 1/true
-Float      | floating point number      | -3.4e -38 | 3.4e 38
-Double     | double precision floating point number | -1.7e -300 | 1.7e 300
-String     | character string           | n/a  | n/a
-ByteBuffer | buffer of bytes (aka BLOB) | n/a | n/a
+uint8      | unsigned 8-bit integer     | 0    | 255
+int8       | signed 8-bit integer       | -128 | 127
+uint16     | unsigned 16-bit integer    |  0   | 65535
+int16      | signed 16-bit integer      | -32768 | 32767
+uint32     | unsigned 32-bit integer    | 0 | 4294967295
+int32      | signed 32-bit integer      | -2147483648 | 2147483647
+uint64     | unsigned 64-bit integer    | 0    | 2^64
+int64      | signed 64-bit integer      | -2^63 | 2^63 - 1
+boolean    | boolean value              | 0/false | 1/true
+float      | floating point number      | -3.4e -38 | 3.4e 38
+double     | double precision floating point number | -1.7e -300 | 1.7e 300
+string     | character string           | n/a  | n/a
+byteBuffer | buffer of bytes (aka BLOB) | n/a | n/a
 
 
 ## Arrays

--- a/spec/Cabin/Cabin.vspec
+++ b/spec/Cabin/Cabin.vspec
@@ -72,7 +72,7 @@
   description: Sun roof status.
 
 - Sunroof.Position:
-  datatype: Int8
+  datatype: int8
   type: sensor
   min: -100
   max: 100

--- a/spec/Cabin/Infotainment.vspec
+++ b/spec/Cabin/Infotainment.vspec
@@ -77,7 +77,7 @@
   description: A navigation has been selected.
 
 - Navigation.DestinationSet.Latitude:
-  datatype: Double
+  datatype: double
   type: actuator
   min: -90
   max: 90
@@ -85,7 +85,7 @@
   description: Latitude of destination
 
 - Navigation.DestinationSet.Longitude:
-  datatype: Double
+  datatype: double
   type: actuator
   min: -180
   max: 180
@@ -98,7 +98,7 @@
   description: The current latitude and longitude of the vehicle.
 
 - Navigation.CurrentLocation.Latitude:
-  datatype: Double
+  datatype: double
   type: sensor
   min: -90
   max: 90
@@ -106,7 +106,7 @@
   description: Current latitude of vehicle, as reported by GPS.
 
 - Navigation.CurrentLocation.Longitude:
-  datatype: Double
+  datatype: double
   type: sensor
   min: -180
   max: 180
@@ -114,7 +114,7 @@
   description: Current longitude of vehicle, as reported by GPS.
 
 - Navigation.CurrentLocation.Heading:
-  datatype: Double
+  datatype: double
   type: sensor
   min: 0
   max: 360
@@ -122,13 +122,13 @@
   description: Current magnetic compass heading, in degrees.
 
 - Navigation.CurrentLocation.Accuracy:
-  datatype: Double
+  datatype: double
   type: sensor
   unit: m
   description: Accuracy level of the latitude and longitude coordinates in meters.
 
 - Navigation.CurrentLocation.Altitude:
-  datatype: Double
+  datatype: double
   type: sensor
   unit: m
   description: Current elevation of the position in meters.

--- a/spec/Chassis/Chassis.vspec
+++ b/spec/Chassis/Chassis.vspec
@@ -154,7 +154,7 @@
   description: Steering wheel signals
 
 - SteeringWheel.Angle:
-  datatype: Int16
+  datatype: int16
   type: sensor
   unit: degrees
   description: Steering wheel angle. Positive = degrees to the left. Negative = degrees to the right.

--- a/spec/Driver/Driver.vspec
+++ b/spec/Driver/Driver.vspec
@@ -35,6 +35,6 @@
   description: Fatigueness level of driver. Evaluated by multiple factors like trip time, behaviour of steering, eye status.
 
 - HeartRate:
-  datatype: UInt16
+  datatype: Uint16
   type: sensor
   description: Heart rate of the driver.

--- a/spec/Driver/Driver.vspec
+++ b/spec/Driver/Driver.vspec
@@ -35,6 +35,6 @@
   description: Fatigueness level of driver. Evaluated by multiple factors like trip time, behaviour of steering, eye status.
 
 - HeartRate:
-  datatype: Uint16
+  datatype: uint16
   type: sensor
   description: Heart rate of the driver.

--- a/spec/Powertrain/Battery.vspec
+++ b/spec/Powertrain/Battery.vspec
@@ -42,7 +42,7 @@
 
 - Battery.StateOfCharge.Target:
   type: actuator
-  datatype: Uint8
+  datatype: uint8
   min: 0
   max: 100
   unit: percent

--- a/spec/Powertrain/Battery.vspec
+++ b/spec/Powertrain/Battery.vspec
@@ -27,14 +27,14 @@
 - Battery.StateOfCharge.Current:
   type: sensor
   unit: percent
-  datatype: Float
+  datatype: float
   min: 0
   max: 100.00
   description: Physical state of charge of the high voltage battery. This is not necessarily the state of charge being displayed to the customer.
 
 - Battery.StateOfCharge.Displayed:
   type: sensor
-  datatype: Float
+  datatype: float
   unit: percent
   min: 0
   max: 100.00

--- a/spec/Powertrain/Battery.vspec
+++ b/spec/Powertrain/Battery.vspec
@@ -42,7 +42,7 @@
 
 - Battery.StateOfCharge.Target:
   type: actuator
-  datatype: UInt8
+  datatype: Uint8
   min: 0
   max: 100
   unit: percent

--- a/spec/Powertrain/ElectricMotor.vspec
+++ b/spec/Powertrain/ElectricMotor.vspec
@@ -52,7 +52,7 @@
 # Motor rotations per minute
 #
 - Motor.Rpm:
-  datatype: Uint32
+  datatype: uint32
   type: sensor
   unit: rpm
   min: -100000

--- a/spec/Private/CARFIT/Chassis/Chassis.vspec
+++ b/spec/Private/CARFIT/Chassis/Chassis.vspec
@@ -8,7 +8,7 @@
 # Steering Wheel
 #
 - SteeringWheelBias.Angle:
-  type: Int16
+  type: int16
   unit: degrees
   description: Steering wheel bias angle (offset). Positive = degrees to the left. Negative = degrees to the right.
 

--- a/spec/Private/CARFIT/Chassis/Chassis.vspec
+++ b/spec/Private/CARFIT/Chassis/Chassis.vspec
@@ -25,17 +25,17 @@
   description: Alignment status. True = Is aligned. False = Is out of alignment.
 
 - Alignment.Caster:
-  type: Uint8
+  type: uint8
   unit: degrees
   description: Caster in degrees.  Positive = right caster, Negative = left caster
 
 - Alignment.Camber:
-  type: Uint8
+  type: uint8
   unit: degrees
   description: Camber in degrees.  Positive = right camber, Negative = left camber
 
 - Alignment.Toe:
-  type: Uint8
+  type: uint8
   unit: degrees
   description: Toe in degrees.  Positive = right toe, Negative = left toe
 

--- a/spec/Private/CARFIT/Chassis/Wheel.vspec
+++ b/spec/Private/CARFIT/Chassis/Wheel.vspec
@@ -12,7 +12,7 @@
   description: Brake pad wear status. True = Worn. False = Not Worn.
 
 - Brake.RotorWear:
-  type: Uint16
+  type: uint16
   description: Brake rotor wear as a percent.  0 = No Wear.  100 = Replace.
 
 - Brake.RotorThin:

--- a/spec/Private/CARFIT/Drivetrain/Engine.vspec
+++ b/spec/Private/CARFIT/Drivetrain/Engine.vspec
@@ -23,6 +23,6 @@
   description: Drive shaft condition.  True = good condition.  False = bad condition
 
 - DriveShaft.Angle:
-  type: Uint8
+  type: uint8
   uint: degrees
   description: Drive shaft angle in degrees.  This impacts trucks.

--- a/spec/Private/CARFIT/Vehicle/Vehicle.vspec
+++ b/spec/Private/CARFIT/Vehicle/Vehicle.vspec
@@ -9,16 +9,16 @@
 #
 
 - StopAndGoTime:
-  type: Uint32
+  type: uint32
   unit: s
   description: Accumulated time spent under 10kph.
 
 - SurfaceStreetTime:
-  type: Uint32
+  type: uint32
   unit: s
   description: Accumulated time spent under and including 70kph.
 
 - HighwayTime:
-  type: Uint32
+  type: uint32
   unit: s
   description: Accumulated time spent over 70kph.


### PR DESCRIPTION
Harmonize all units to lowercase (that was the majority, and easier to type), and also adapt the documentation.

I am not sure if we _require_ lower casp anywhhere, or both is valid, but in either case we should not be "messy" about this in the core spec.

This should fix #210 

After generating json locally:
```
$ cat vss_rel_2.0.0-alpha+006.json | grep datatype |  sed "s/^[ \t]*//" | sort | uniq 
"datatype": "boolean",
"datatype": "double",
"datatype": "float",
"datatype": "int16",
"datatype": "int32",
"datatype": "int8",
"datatype": "string",
"datatype": "string[]",
"datatype": "uint16",
"datatype": "uint32",
"datatype": "uint8",
"datatype": "uint8[]",
```

Somebody (Travis?) needs to check if the docs still generate, I do not know Hugo, and just installing it lead to some errors on my side (no matter I modify or not)

```
ERROR 2020/11/09 20:21:35 render of "page" failed: execute of template failed: template: _default/single.html:1:3: executing "_default/single.html" at <partial "header.html" .>: error calling partial: execute of template failed: template: partials/header.html:40:7: executing "partials/header.html" at <partial "menu.html" .>: error calling partial: "/home/sebastian/vehicle_signal_specification/docs-gen/themes/learn/layouts/partials/menu.html:100:23": execute of template failed: template: partials/menu.html:100:23: executin
```
