### PR TITLE
Update Hugo theme version to work with newer Hugo releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ language: python3
 
 env:
   global:
-    - HUGO_VER=0.69.0
+    - HUGO_VER=0.78.1
     - DOCS_DIR='./docs-gen'
     - TOOLS_DIR='./vss-tools'
 


### PR DESCRIPTION
I noticed in #212 that hugo docsk do not build with default hugo in Ubunutu 20.04

Ubuntu (snap) uses
```
Hugo Static Site Generator v0.78.1 linux/amd64 BuildDate: 2020-11-05T14:07:53Z
```

Updating the submodule referring to the theme seems to fix that.

Somebody check, that is doesn't breaks anything else. Haven't touched travis. Maybe also needs to be upgraded