### PR TITLE
Add carets to clarify powers

### DIFF
--- a/docs-gen/content/rule_set/data_entry/data_unit_types.md
+++ b/docs-gen/content/rule_set/data_entry/data_unit_types.md
@@ -36,8 +36,8 @@ g          | Weight        | Grams
 kg         | Weight        | Kilograms
 g/s        | Flow          | Grams per second
 l/h        | Flow          | Liters per hour
-m/s2       | Acceleration  | Acceleration in meters per second squared
-cm/s2      | Acceleration  | Acceleration in centimeters per second squared
+m/s^2      | Acceleration  | Acceleration in meters per second squared
+cm/s^2     | Acceleration  | Acceleration in centimeters per second squared
 N          | Force         | Newton
 Nm         | Force         | Torque
 l          | Volume        | Liter

--- a/spec/Powertrain/CombustionEngine.vspec
+++ b/spec/Powertrain/CombustionEngine.vspec
@@ -20,7 +20,7 @@
   datatype: uint16
   type: attribute
   description: Displacement in cubic centimetres.
-  unit: cm3
+  unit: cm^3
 
 - Configuration:
   datatype: string

--- a/spec/Vehicle/Vehicle.vspec
+++ b/spec/Vehicle/Vehicle.vspec
@@ -225,19 +225,19 @@
 - Acceleration.Longitudinal:
   datatype: int32
   type: sensor
-  unit: m/s2
+  unit: m/s^2
   description: Vehicle acceleration in X (longitudinal acceleration).
 
 - Acceleration.Lateral:
   datatype: int32
   type: sensor
-  unit: m/s2
+  unit: m/s^2
   description: Vehicle acceleration in Y (lateral acceleration).
 
 - Acceleration.Vertical:
   datatype: int32
   type: sensor
-  unit: m/s2
+  unit: m/s^2
   description: Vehicle acceleration in Z (vertical acceleration).
 
 


### PR DESCRIPTION
Right now, `m/s2` and `cm/s2` are used for for meters per square second and centimeters on square second. However, this is a non-traditional syntax and can lead to ambiguities. Instead, I suggest the traditional caret notation.

For example, you have `l/100km` and `Nm`. If I were to combine these three syntaxes in one, what would `N3m` be?

Finally, many parsing programs won't recognize `s2` as squared seconds. The library that I'm using, pint, doesn't.