### PR TITLE
promoting global vehicle data/information to Vehicle root branch

### DIFF
--- a/spec/Cabin/Infotainment.vspec
+++ b/spec/Cabin/Infotainment.vspec
@@ -96,6 +96,7 @@
   type: branch
   aggregate: true
   description: The current latitude and longitude of the vehicle.
+  deprecation: @2.1 moved to Vehicle.CurrentLocation
 
 - Navigation.CurrentLocation.Latitude:
   datatype: Double
@@ -104,6 +105,7 @@
   max: 90
   unit: degrees
   description: Current latitude of vehicle, as reported by GPS.
+  deprecation: @2.1 moved to Vehicle.CurrentLocation.Latitude
 
 - Navigation.CurrentLocation.Longitude:
   datatype: Double
@@ -112,6 +114,7 @@
   max: 180
   unit: degrees
   description: Current longitude of vehicle, as reported by GPS.
+  deprecation: @2.1 moved to Vehicle.CurrentLocation.Longitude
 
 - Navigation.CurrentLocation.Heading:
   datatype: Double
@@ -120,18 +123,21 @@
   max: 360
   unit: degrees
   description: Current magnetic compass heading, in degrees.
+  deprecation: @2.1 moved to Vehicle.CurrentLocation.Heading
 
 - Navigation.CurrentLocation.Accuracy:
   datatype: Double
   type: sensor
   unit: m
   description: Accuracy level of the latitude and longitude coordinates in meters.
+  deprecation: @2.1 moved to Vehicle.CurrentLocation.Accuracy
 
 - Navigation.CurrentLocation.Altitude:
   datatype: Double
   type: sensor
   unit: m
   description: Current elevation of the position in meters.
+  deprecation: @2.1 moved to Vehicle.CurrentLocation.Altitude
 
 - Navigation.CurrentLocation.Speed:
   datatype: uint16
@@ -140,7 +146,7 @@
   max: 250
   unit: km/h
   description: Vehicle speed, as sensed by the GPS receiver.
-
+  deprecation: @2.1 removed because doubled with Vehicle.Speed
 
 - HMI:
   type: branch

--- a/spec/Cabin/Infotainment.vspec
+++ b/spec/Cabin/Infotainment.vspec
@@ -96,7 +96,7 @@
   type: branch
   aggregate: true
   description: The current latitude and longitude of the vehicle.
-  deprecation: @2.1 moved to Vehicle.CurrentLocation
+  deprecation: V2.1 moved to Vehicle.CurrentLocation
 
 - Navigation.CurrentLocation.Latitude:
   datatype: Double
@@ -105,7 +105,7 @@
   max: 90
   unit: degrees
   description: Current latitude of vehicle, as reported by GPS.
-  deprecation: @2.1 moved to Vehicle.CurrentLocation.Latitude
+  deprecation: V2.1 moved to Vehicle.CurrentLocation.Latitude
 
 - Navigation.CurrentLocation.Longitude:
   datatype: Double
@@ -114,7 +114,7 @@
   max: 180
   unit: degrees
   description: Current longitude of vehicle, as reported by GPS.
-  deprecation: @2.1 moved to Vehicle.CurrentLocation.Longitude
+  deprecation: V2.1 moved to Vehicle.CurrentLocation.Longitude
 
 - Navigation.CurrentLocation.Heading:
   datatype: Double
@@ -123,21 +123,21 @@
   max: 360
   unit: degrees
   description: Current magnetic compass heading, in degrees.
-  deprecation: @2.1 moved to Vehicle.CurrentLocation.Heading
+  deprecation: V2.1 moved to Vehicle.CurrentLocation.Heading
 
 - Navigation.CurrentLocation.Accuracy:
   datatype: Double
   type: sensor
   unit: m
   description: Accuracy level of the latitude and longitude coordinates in meters.
-  deprecation: @2.1 moved to Vehicle.CurrentLocation.Accuracy
+  deprecation: V2.1 moved to Vehicle.CurrentLocation.Accuracy
 
 - Navigation.CurrentLocation.Altitude:
   datatype: Double
   type: sensor
   unit: m
   description: Current elevation of the position in meters.
-  deprecation: @2.1 moved to Vehicle.CurrentLocation.Altitude
+  deprecation: V2.1 moved to Vehicle.CurrentLocation.Altitude
 
 - Navigation.CurrentLocation.Speed:
   datatype: uint16
@@ -146,7 +146,7 @@
   max: 250
   unit: km/h
   description: Vehicle speed, as sensed by the GPS receiver.
-  deprecation: @2.1 removed because doubled with Vehicle.Speed
+  deprecation: V2.1 removed because doubled with Vehicle.Speed
 
 - HMI:
   type: branch

--- a/spec/Chassis/Chassis.vspec
+++ b/spec/Chassis/Chassis.vspec
@@ -226,10 +226,10 @@
 - Trailer:
   type: branch
   description: Trailer signals
-  deprecation: @2.1 moved branch to Vehicle.Trailer
+  deprecation: @2.1 moved to Vehicle.Trailer
 
 - Trailer.Connected:
   datatype: boolean
   type: sensor
   description: Signal indicating if trailer is connected or not.
-  deprecation: @2.1 moved to Vehicle.Trailer.Width
+  deprecation: @2.1 moved to Vehicle.Trailer.Connected

--- a/spec/Chassis/Chassis.vspec
+++ b/spec/Chassis/Chassis.vspec
@@ -19,7 +19,7 @@
   default: 0
   unit: kg
   description: Vehicle curb weight, in kg, including all liquids and full tank of fuel, but no cargo or passengers.
-  deprecation: @2.1 moved to Vehicle.CurbWeight
+  deprecation: V2.1 moved to Vehicle.CurbWeight
 
 - GrossWeight:
   datatype: uint16
@@ -27,7 +27,7 @@
   default: 0
   unit: kg
   description: Curb weight of vehicle, including all liquids and full tank of fuel and full load of cargo and passengers.
-  deprecation: @2.1 moved to Vehicle.GrossWeight
+  deprecation: V2.1 moved to Vehicle.GrossWeight
 
 - TowWeight:
   datatype: uint16
@@ -35,7 +35,7 @@
   default: 0
   unit: kg
   description: Maximum weight, in kilos, of trailer.
-  deprecation: @2.1 moved to Vehicle.TowWeight
+  deprecation: V2.1 moved to Vehicle.TowWeight
 
 - Length:
   datatype: uint16
@@ -43,7 +43,7 @@
   default: 0
   unit: mm
   description: Overall vehicle length, in mm.
-  deprecation: @2.1 moved to Vehicle.Length
+  deprecation: V2.1 moved to Vehicle.Length
 
 - Height:
   datatype: uint16
@@ -51,7 +51,7 @@
   default: 0
   unit: mm
   description: Overall vehicle height, in mm.
-  deprecation: @2.1 moved to Vehicle.Height
+  deprecation: V2.1 moved to Vehicle.Height
 
 - Width:
   datatype: uint16
@@ -59,7 +59,7 @@
   default: 0
   unit: mm
   description: Overall vehicle width, in mm.
-  deprecation: @2.1 moved to Vehicle.Width
+  deprecation: V2.1 moved to Vehicle.Width
 
 - Wheelbase:
   datatype: uint16
@@ -226,10 +226,10 @@
 - Trailer:
   type: branch
   description: Trailer signals
-  deprecation: @2.1 moved to Vehicle.Trailer
+  deprecation: V2.1 moved to Vehicle.Trailer
 
 - Trailer.Connected:
   datatype: boolean
   type: sensor
   description: Signal indicating if trailer is connected or not.
-  deprecation: @2.1 moved to Vehicle.Trailer.Connected
+  deprecation: V2.1 moved to Vehicle.Trailer.Connected

--- a/spec/Chassis/Chassis.vspec
+++ b/spec/Chassis/Chassis.vspec
@@ -19,6 +19,7 @@
   default: 0
   unit: kg
   description: Vehicle curb weight, in kg, including all liquids and full tank of fuel, but no cargo or passengers.
+  deprecation: @2.1 moved to Vehicle.CurbWeight
 
 - GrossWeight:
   datatype: uint16
@@ -26,6 +27,7 @@
   default: 0
   unit: kg
   description: Curb weight of vehicle, including all liquids and full tank of fuel and full load of cargo and passengers.
+  deprecation: @2.1 moved to Vehicle.GrossWeight
 
 - TowWeight:
   datatype: uint16
@@ -33,6 +35,7 @@
   default: 0
   unit: kg
   description: Maximum weight, in kilos, of trailer.
+  deprecation: @2.1 moved to Vehicle.TowWeight
 
 - Length:
   datatype: uint16
@@ -40,6 +43,7 @@
   default: 0
   unit: mm
   description: Overall vehicle length, in mm.
+  deprecation: @2.1 moved to Vehicle.Length
 
 - Height:
   datatype: uint16
@@ -47,6 +51,7 @@
   default: 0
   unit: mm
   description: Overall vehicle height, in mm.
+  deprecation: @2.1 moved to Vehicle.Height
 
 - Width:
   datatype: uint16
@@ -54,6 +59,7 @@
   default: 0
   unit: mm
   description: Overall vehicle width, in mm.
+  deprecation: @2.1 moved to Vehicle.Width
 
 - Wheelbase:
   datatype: uint16
@@ -220,8 +226,10 @@
 - Trailer:
   type: branch
   description: Trailer signals
+  deprecation: @2.1 moved branch to Vehicle.Trailer
 
 - Trailer.Connected:
   datatype: boolean
   type: sensor
   description: Signal indicating if trailer is connected or not.
+  deprecation: @2.1 moved to Vehicle.Trailer.Width

--- a/spec/Vehicle/Vehicle.vspec
+++ b/spec/Vehicle/Vehicle.vspec
@@ -295,3 +295,123 @@
   type: attribute
   description: The CO2 emissions in g/km.
   unit: g/km
+
+
+#
+# Vehicle Weight and Dimension attributes
+#
+
+- CurrentOverallWeight:
+  datatype: uint16
+  type: sensor
+  value: 0
+  unit: kg
+  description: Current overall Vehicle weight, in kg, including all liquids and full tank of fuel.
+
+- CurbWeight:
+  datatype: uint16
+  type: attribute
+  value: 0
+  unit: kg
+  description: Vehicle curb weight, in kg, including all liquids and full tank of fuel, but no cargo or passengers.
+
+- GrossWeight:
+  datatype: uint16
+  type: attribute
+  value: 0
+  unit: kg
+  description: Curb weight of vehicle, including all liquids and full tank of fuel and full load of cargo and passengers.
+
+- MaxTowWeight:
+  datatype: uint16
+  type: attribute
+  value: 0
+  unit: kg
+  description: Maximum weight, in kilos, of trailer.
+
+- MaxTowBallWeight:
+  datatype: uint16
+  type: attribute
+  value: 0
+  unit: kg
+  description: Maximum vertical weight on the tow ball, in kilos, of a trailer.
+
+- Length:
+  datatype: uint16
+  type: attribute
+  value: 0
+  unit: mm
+  description: Overall vehicle length, in mm.
+
+- Height:
+  datatype: uint16
+  type: attribute
+  value: 0
+  unit: mm
+  description: Overall vehicle height, in mm.
+
+- Width:
+  datatype: uint16
+  type: attribute
+  value: 0
+  unit: mm
+  description: Overall vehicle width, in mm.
+
+
+#
+# Trailer
+#
+- Trailer:
+  type: branch
+  description: Trailer signals
+
+- Trailer.Connected:
+  datatype: boolean
+  type: sensor
+  description: Signal indicating if trailer is connected or not.
+
+#
+# Location
+#
+
+- CurrentLocation:
+  type: branch
+  aggregate: true
+  description: The current latitude and longitude of the vehicle.
+
+- CurrentLocation.Latitude:
+  datatype: double
+  type: sensor
+  min: -90
+  max: 90
+  unit: degrees
+  description: Current latitude of vehicle, as reported by GPS.
+
+- CurrentLocation.Longitude:
+  datatype: double
+  type: sensor
+  min: -180
+  max: 180
+  unit: degrees
+  description: Current longitude of vehicle, as reported by GPS.
+
+- CurrentLocation.Heading:
+  datatype: double
+  type: sensor
+  min: 0
+  max: 360
+  unit: degrees
+  description: Current magnetic compass heading, in degrees.
+
+- CurrentLocation.Accuracy:
+  datatype: double
+  type: sensor
+  unit: m
+  description: Accuracy level of the latitude and longitude coordinates in meters.
+
+- CurrentLocation.Altitude:
+  datatype: double
+  type: sensor
+  unit: m
+  description: Current elevation of the position in meters.
+

--- a/spec/Vehicle/Vehicle.vspec
+++ b/spec/Vehicle/Vehicle.vspec
@@ -293,7 +293,7 @@
 - emissionsCO2:
   datatype: int16
   type: attribute
-  description: The CO2 emissions in g/km.
+  description: The CO2 emissions.
   unit: g/km
 
 
@@ -306,14 +306,14 @@
   type: sensor
   value: 0
   unit: kg
-  description: Current overall Vehicle weight, in kg, including all liquids and full tank of fuel.
+  description: Current overall Vehicle weight. Including passengers, cargo and other load inside the car.
 
 - CurbWeight:
   datatype: uint16
   type: attribute
   value: 0
   unit: kg
-  description: Vehicle curb weight, in kg, including all liquids and full tank of fuel, but no cargo or passengers.
+  description: Vehicle curb weight, including all liquids and full tank of fuel, but no cargo or passengers.
 
 - GrossWeight:
   datatype: uint16
@@ -327,35 +327,35 @@
   type: attribute
   value: 0
   unit: kg
-  description: Maximum weight, in kilos, of trailer.
+  description: Maximum weight of trailer.
 
 - MaxTowBallWeight:
   datatype: uint16
   type: attribute
   value: 0
   unit: kg
-  description: Maximum vertical weight on the tow ball, in kilos, of a trailer.
+  description: Maximum vertical weight on the tow ball of a trailer.
 
 - Length:
   datatype: uint16
   type: attribute
   value: 0
   unit: mm
-  description: Overall vehicle length, in mm.
+  description: Overall vehicle length.
 
 - Height:
   datatype: uint16
   type: attribute
   value: 0
   unit: mm
-  description: Overall vehicle height, in mm.
+  description: Overall vehicle height.
 
 - Width:
   datatype: uint16
   type: attribute
   value: 0
   unit: mm
-  description: Overall vehicle width, in mm.
+  description: Overall vehicle width.
 
 
 #
@@ -385,7 +385,7 @@
   min: -90
   max: 90
   unit: degrees
-  description: Current latitude of vehicle, as reported by GPS.
+  description: Current latitude of vehicle.
 
 - CurrentLocation.Longitude:
   datatype: double
@@ -393,7 +393,7 @@
   min: -180
   max: 180
   unit: degrees
-  description: Current longitude of vehicle, as reported by GPS.
+  description: Current longitude of vehicle.
 
 - CurrentLocation.Heading:
   datatype: double
@@ -401,17 +401,17 @@
   min: 0
   max: 360
   unit: degrees
-  description: Current magnetic compass heading, in degrees.
+  description: Current magnetic compass heading.
 
 - CurrentLocation.Accuracy:
   datatype: double
   type: sensor
   unit: m
-  description: Accuracy level of the latitude and longitude coordinates in meters.
+  description: Accuracy level of the latitude and longitude coordinates.
 
 - CurrentLocation.Altitude:
   datatype: double
   type: sensor
   unit: m
-  description: Current elevation of the position in meters.
+  description: Current elevation of the position.
 


### PR DESCRIPTION
promoting global vehicle data/information to Vehicle root branch **_using deprecation_**

### removed
Navigation.CurrentLocation.Speed **removed** because doubled with Vehicle.Speed

### moved
complete branch: Navigation.CurrentLocation moved to Vehicle.CurrentLocation
complete branch: Chassis.Trailer moved to Vehicle.Trailer
Vehicle masses moved from Chassis to Vehicle

Signed-off-by: Christian Heissenberger <christian.heissenberger@de.bosch.com>