### PR TITLE
Removing duplicated HVAC entries

### DIFF
--- a/spec/Cabin/Cabin.vspec
+++ b/spec/Cabin/Cabin.vspec
@@ -28,32 +28,6 @@
   description: Climate control
 #include HVAC.vspec HVAC
 
-- HVAC.IsRecirculationActive:
-  datatype: boolean
-  type: actuator
-  description: Is recirculation active.
-
-- HVAC.IsFrontDefrosterActive:
-  datatype: boolean
-  type: actuator
-  description: Is front defroster active.
-
-- HVAC.IsRearDefrosterActive:
-  datatype: boolean
-  type: actuator
-  description: Is rear defroster active.
-
-- HVAC.IsAirConditioningActive:
-  datatype: boolean
-  type: actuator
-  description: Is Air conditioning active.
-
-- HVAC.AmbientAirTemperature:
-  datatype: float
-  type: sensor
-  unit: celsius
-  description: Ambient air temperature
-
 ##
 # Infotainment
 ##


### PR DESCRIPTION
The removed entries also exist with identical properties in the included HVAC.vspec