### PR TITLE
Using float for speed and acceleration (Fixes #228)

### DIFF
--- a/spec/ADAS/ADAS.vspec
+++ b/spec/ADAS/ADAS.vspec
@@ -34,7 +34,7 @@
 
 
 - CruiseControl.SpeedSet:
-  datatype: int32
+  datatype: float
   type: actuator
   unit: km/h
   description: Set cruise control speed in kilometers per hour

--- a/spec/Powertrain/Transmission.vspec
+++ b/spec/Powertrain/Transmission.vspec
@@ -48,6 +48,7 @@
   max: 250
   unit: km/h
   description: Vehicle speed, as sensed by the gearbox.
+  deprecation: V2.1 removed because doubled with Vehicle.Speed
 
 
 #

--- a/spec/Vehicle/Vehicle.vspec
+++ b/spec/Vehicle/Vehicle.vspec
@@ -175,12 +175,10 @@
   description: Accumulated idle time in seconds.
 
 - Speed:
-  datatype: int32
+  datatype: float
   type: sensor
-  min: -250
-  max: 250
   unit: km/h
-  description: Vehicle speed, as sensed by the gearbox.
+  description: Vehicle speed
 
 - TravelledDistance:
   datatype: float
@@ -207,10 +205,8 @@
   description: Indicates whether the vehicle is stationary or moving
 
 - AverageSpeed:
-  datatype: int32
+  datatype: float
   type: sensor
-  min: -250
-  max: 250
   unit: km/h
   description: Average speed for the current trip
 
@@ -223,19 +219,19 @@
   description: Spatial acceleration
 
 - Acceleration.Longitudinal:
-  datatype: int32
+  datatype: float
   type: sensor
   unit: m/s^2
   description: Vehicle acceleration in X (longitudinal acceleration).
 
 - Acceleration.Lateral:
-  datatype: int32
+  datatype: float
   type: sensor
   unit: m/s^2
   description: Vehicle acceleration in Y (lateral acceleration).
 
 - Acceleration.Vertical:
-  datatype: int32
+  datatype: float
   type: sensor
   unit: m/s^2
   description: Vehicle acceleration in Z (vertical acceleration).
@@ -281,6 +277,7 @@
   type: attribute
   unit: s
   description: The time needed to accelerate the vehicle from a given start velocity to a given target velocity.
+  deprecation: V2.1 removed as ambiguous definition (start/stop-speed not defined)
 
 - cargoVolume:
   datatype: int16


### PR DESCRIPTION
This makes it possible to use data with higher accuracy. This can be especially important with speed where multiple conversions may happen. For example - a vehicle may internally represent speed as m/s, but the end-user might want to work with miles/hour. If using int-representation (without decimals) for the intermediate format, then it might become important whether values shall be rounded upwards/downwards

Example: Assume a car driver wants to set cruise control to 70 mph. This corresponds to 112.6 km/h.  If using integer-representation (without decimals) the service using the actuator must make an active decision on whether it shall request 112 km/h or 113 km/h. In this case just rounding to 113 km/h theoretically might give legal problems (the car will move faster than requested by the user, and possibly exceed speed limits).  
