### PR TITLE
Using float and millimetres for bore and stroke

### DIFF
--- a/spec/Powertrain/CombustionEngine.vspec
+++ b/spec/Powertrain/CombustionEngine.vspec
@@ -24,16 +24,16 @@
   unit: cm^3
 
 - StrokeLength:
-  datatype: uint16
+  datatype: float
   type: attribute
-  description: Stroke length in centimetres.
-  unit: cm
+  description: Stroke length in millimetres.
+  unit: mm
 
 - Bore:
-  datatype: uint16
+  datatype: float
   type: attribute
-  description: Bore in centimetres.
-  unit: cm
+  description: Bore in millimetres.
+  unit: mm
 
 - Configuration:
   datatype: string


### PR DESCRIPTION
Stroke and bore are typically expressed with 0.1 mm precision, see examples below.
Expressing stroke/bore in centimetres is quite rare, so changed to millimetres as agreed in last VSS meeting.
With this it will e.g. be possible to represent this Golf as 82.5 x 92.8 mm.

https://www.ultimatespecs.com/car-specs/Volkswagen/109792/Volkswagen-Golf-2017-R-20-TSI-310HP-DSG-7.html
https://www.scania.com/content/dam/scanianoe/market/master/products-and-services/engines/pdf/specs/marine/DI16076M_846kW.pdf