### PR TITLE
Changing volume-related datapoints to float

### DIFF
--- a/spec/Powertrain/CombustionEngine.vspec
+++ b/spec/Powertrain/CombustionEngine.vspec
@@ -65,13 +65,13 @@
   unit: s
 
 - EngineOilCapacity:
-  datatype: uint16
+  datatype: float
   type: attribute
   description: Engine oil capacity in liters.
   unit: l
 
 - EngineCoolantCapacity:
-  datatype: uint16
+  datatype: float
   type: attribute
   description: Engine coolant capacity in liters.
   unit: l

--- a/spec/Powertrain/FuelSystem.vspec
+++ b/spec/Powertrain/FuelSystem.vspec
@@ -25,9 +25,8 @@
   description: Defines the hybrid type of the vehicle
 
 - TankCapacity:
-  datatype: uint16
+  datatype: float
   type: attribute
-  default: 0
   unit: l
   description: Capacity of the fuel tank in liters
 
@@ -58,18 +57,21 @@
   unit: l/100km
   min: 0
   description: Average consumption in liters per 100 km.
+# The period used to calculate average consumption is OEM-specific
+# It may e.g. be average consumption since start of current trip,
+# since a user-initiated reset or during the lifetime of the vehicle.
 
 - ConsumptionSinceStart:
   datatype: float
   type: sensor
   unit: l
-  description: Fuel amount consumed since start in liters.
+  description: Fuel amount in liters consumed since start of current trip.
 
 - TimeSinceStart:
   datatype: uint32
   type: sensor
   unit: s
-  description: Time elapsed since start in seconds.
+  description: Time in seconds elapsed since start of current trip.
 
 - EngineStopStartEnabled:
   datatype: boolean

--- a/spec/Vehicle/Vehicle.vspec
+++ b/spec/Vehicle/Vehicle.vspec
@@ -280,12 +280,11 @@
   deprecation: V2.1 removed as ambiguous definition (start/stop-speed not defined)
 
 - cargoVolume:
-  datatype: int16
+  datatype: float
   type: attribute
   unit: l
   description: The available volume for cargo or luggage. For automobiles, this is usually the trunk volume.
   min: 0
-  max: 100
 
 - emissionsCO2:
   datatype: int16


### PR DESCRIPTION
Also clarifying meaning of some "average" datapoints.
It can be noted that some OEM, like e.g. Mercedes
(https://developer.mercedes-benz.com/products/connect_your_fleet/details)
differentiate between "SinceReset" and "SinceStart".
While other like Volvo
(https://developer.volvocars.com/volvo-api/extended-vehicle/#Average_Fuel_Consumption)
does not specify how "average" is calculated.