### PR TITLE
Deprecating Transmission.TravelledDistance

### DIFF
--- a/spec/Powertrain/Transmission.vspec
+++ b/spec/Powertrain/Transmission.vspec
@@ -59,6 +59,7 @@
   type: sensor
   unit: km
   description: Odometer reading
+  deprecation: V2.1 removed because doubled with Vehicle.TravelledDistance
 
 
 #


### PR DESCRIPTION
Same description as Vehicle.TravelledDistance.
Haven't heard of any vehicle maintaining more than one (1) odometer value