### PR TITLE
Improving documentation for TravelledDistance

### DIFF
--- a/spec/Powertrain/Transmission.vspec
+++ b/spec/Powertrain/Transmission.vspec
@@ -52,13 +52,19 @@
 
 
 #
-# Current odometer reading
+# Current odometer reading for the transmission
+#
+# Note that this signal refers to the distance travelled by the transmission and not the vehicle.
+# This signal might differ from Vehicle.TravelledDistance if the transmission
+# has been replaced during the lifetime of the vehicle.
+# If the transmission is moved from one vehicle to another the signal shall also include
+# distance travelled in previous vehicles.
 #
 - TravelledDistance:
   datatype: float
   type: sensor
   unit: km
-  description: Odometer reading
+  description: Odometer reading, total distance travelled during the lifetime of the transmission.
 
 
 #

--- a/spec/Vehicle/Vehicle.vspec
+++ b/spec/Vehicle/Vehicle.vspec
@@ -184,7 +184,7 @@
   datatype: float
   type: sensor
   unit: km
-  description: Odometer reading
+  description: Odometer reading, total distance travelled during the lifetime of the vehicle.
 
 - TripMeterReading:
   datatype: float


### PR DESCRIPTION
Previously Vehicle.TravelledDistance and Transmission.TravelledDistance had the same description. In VSS meeting it was discussed whether they could be considered as duplicates or if they actually have different meaning. It was agreed that they might be different, if the transmission has been replaced you might want to keep track of the wear/usage of the new/replacement transmission separately.