### PR TITLE
vss-tools & Makefile: include ocf, protobuf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@
 # Makefile to generate specifications
 #
 
-.PHONY: clean all json franca csv binary c tests travis_targets
+.PHONY: clean all travis_targets json franca csv tests binary protobuf ocf c install deploy
 
-all: clean json franca csv binary c tests
+all: clean json franca csv binary tests protobuf
 
 # All targets that shall be built on each pull request for
 # vehicle-signal-specification or vss-tools
@@ -32,6 +32,12 @@ tests:
 binary:
 	gcc -shared -o ${TOOLSDIR}/binary/binarytool.so -fPIC ${TOOLSDIR}/binary/binarytool.c
 	${TOOLSDIR}/vspec2binary.py -i:./spec/VehicleSignalSpecification.id ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).binary
+
+protobuf:
+	${TOOLSDIR}/contrib/vspec2protobuf.py -i:spec/VehicleSignalSpecification.id -I ./spec ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).proto
+
+ocf:
+	${TOOLSDIR}/contrib/ocf/vspec2ocf.py -i PREFIX:spec/VehicleSignalSpecification.id:1 -I ./spec ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).ocf.json
 
 c:
 	(cd ${TOOLSDIR}/vspec2c/; make )


### PR DESCRIPTION
This is a tools bump to include the most recent additions to vss-tools

Should be straight forward, therefore SHORT REVIEW PERIOD! :) 

Shortlog:

  - c29206f Move vspec2protobuf to contrib/
  - 413c74e Add vspec2protobuf, using anytree
  - 1076588 Go build script and Go parser update.
  - 4dbc6e0 Move ocf related tools and create contrib/ dir
  - e075559 vspec2ocf: Fix printfs to be python3 compliant
  - e905aab Updates to binary tool

Some issues missed in previous merges: Bugfix the protobuf target in Makefile and include target for ocf. (OCF tooling is unmaintained but some fix included so might as well have the Makefile target for further testing)