### PR TITLE
Adding service signals

### DIFF
--- a/spec/Powertrain/CombustionEngine.vspec
+++ b/spec/Powertrain/CombustionEngine.vspec
@@ -58,10 +58,12 @@
   type: attribute
   description: Engine compression ratio.
 
+# In addition to this a signal a vehicle can report remaining time to service (including e.g. oil change)
+# by Vehicle.Service.TimeToService
 - OilLifeRemaining:
-  datatype: uint32
-  type: attribute
-  description: Remaining engine oil life in seconds.
+  datatype: int32
+  type: sensor
+  description: Remaining engine oil life in seconds. Negative values can be used to indicate that lifetime has been exceeded.
   unit: s
 
 - EngineOilCapacity:

--- a/spec/Vehicle/Service.vspec
+++ b/spec/Vehicle/Service.vspec
@@ -1,0 +1,52 @@
+#
+# (C) 2021 Robert Bosch GmbH
+#
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
+#
+#
+# Service data
+#
+# This file contains signals relevant for service/maintenance of the vehicle,
+# giving information on when service is needed.
+# As of now VSS does not make any assumptions on what is included in a "service".
+# A "service" is anything that needs to be done by a technician at a garage.
+# It can include e.g. inspection, lubrication as well as replacement of fluids or other parts.
+#
+# For TimeToService int32 and seconds are used, allowing service intervals of up to
+# 68 years to be represented.
+#
+# The signals support negative values, but use of negative values are optional.
+# Once a signal reach 0 (i.e. vehicle is due for service) the vehicle might
+# either stop decreasing the signal, or continue decreasing using negative values
+# to indicate overdue distance/time.
+#
+
+#
+# Service Due Indicator
+# Indicates that it is now or in the near future time to bring the vehicle to a garage for service (of any kind).
+# The criteria for setting "ServiceDue" is not specified by VSS.
+# It may, but do not need to, be based on DistanceToService and TimeToService.
+#
+- ServiceDue:
+  datatype: boolean
+  type: sensor
+  description: Indicates if vehicle needs service (of any kind). True = Service needed now or in the near future. False = No known need for service.
+
+#
+# Remaining distance to service (of any kind).
+#
+- DistanceToService:
+  datatype: float
+  type: sensor
+  unit: km
+  description: Remaining distance to service (of any kind). Negative values indicate service overdue.
+
+#
+# Remaining time to service (of any kind).
+#
+- TimeToService:
+  datatype: int32
+  type: sensor
+  unit: s
+  description: Remaining time to service (of any kind). Negative values indicate service overdue.

--- a/spec/VehicleSignalSpecification.vspec
+++ b/spec/VehicleSignalSpecification.vspec
@@ -209,3 +209,12 @@
 # Driver branch created above and will include Occupant attributes
 
 #include Driver/Driver.vspec Vehicle.Driver
+
+#
+# Service information
+#
+- Vehicle.Service:
+  type: branch
+  description: Service data.
+
+#include Vehicle/Service.vspec Vehicle.Service


### PR DESCRIPTION
Fixes #244

This is a proposal for discussion on coming VSS meetings. 

Current proposal is to add a boolean signal (basically equal to the the service lamp) and two signals to indicate remaining time/distance to service. That would give support for both vehicles that want to communicate remaining time/distance as well as for vehicle that only want to communicate a boolean value. 

More discussions in the issue