### PR TITLE
Temporary change of Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,8 @@ c:
 
 clean:
 	rm -f vss_rel_*
-	(cd ${TOOLSDIR}/vspec2c/; make clean)
+# Temporary change to allow moving vspec2c without causing build errors
+# 	(cd ${TOOLSDIR}/vspec2c/; make clean)
 
 install:
 	git submodule init


### PR DESCRIPTION
This is to make it possible to move vspec2c folder in vss-tools
When moved the Makefile shall be changed to refer to the new location