### PR TITLE
Adding signal for vehicle engine oil level

### DIFF
--- a/spec/Powertrain/CombustionEngine.vspec
+++ b/spec/Powertrain/CombustionEngine.vspec
@@ -58,6 +58,18 @@
   type: attribute
   description: Engine compression ratio.
 
+- EngineOilLevel:
+  datatype: string
+  type: attribute
+  enum: [ 
+    "critically_low",  # Critically low, immediate action required
+    "low",             # Level below recommended range, but not critical
+    "normal",          # Within normal range, no need for driver action
+    "high",            # Level above recommended range, but not critical
+    "critically_high"  # Critically high, immediate action required
+    ]
+  description: Vehicle oil level.
+
 # In addition to this a signal a vehicle can report remaining time to service (including e.g. oil change)
 # by Vehicle.Service.TimeToService
 - OilLifeRemaining:


### PR DESCRIPTION
This is a follow up to #180 to cover the need for a signal on oil level

Having oil level seems to be quite common in APIs, see examples below. Many use enums, some use percent plus boolean indicator. The proposed change here is reasonably aligned with the Volvo and Android representation.

In my view a "subjective" enum makes more sense than an "objective" percentage value, as percentage value might be difficult to interpret as it might be very vehicle dependent. Assume for example an engine with a nominal oil capacity (EngineOilCapacity) of 5 liters. Then oil level might be "critically low" already at 70% (if we consider 0% to mean a vehicle without any oil at all). Also, how sensitive a vehicle is for overfilling with oil might vary.

The intention with the proposed enum comments is to let "normal" indicate that oil is within expected range. I.e if you just have had an oil change and the garage has added EngineOilCapacity liters of oil, then the OilLevel shall be "normal", not "high". I.e. low and high shall indicate something that needs to be addressed, although not critically.


Volvo (https://developer.volvocars.com/volvo-api/extended-vehicle/#Oil_Level)

```
VERY_LOW
LOW
NORMAL
HIGH
VERY_HIGH
```

Android (https://android.googlesource.com/platform/hardware/interfaces/+/master/automotive/vehicle/2.0/types.hal)

```
enum VehicleOilLevel : int32_t {
    /**
     * Oil level values
     */
    CRITICALLY_LOW = 0,
    LOW = 1,
    NORMAL = 2,
    HIGH = 3,
    ERROR = 4,
};

```

Mercedes (https://developer.mercedes-benz.com/products/connect_your_fleet/details)


```
InternalCombustionEngine.Oil.Level | percent | Oil level | onInterval
-- | -- | -- | --
InternalCombustionEngine.Oil.Level.Warning |   | Indicates whether an oil level   warning is triggered true: ok false: oil level is overfilled or underfilled | onInterval and onChange
```

