### PR TITLE
Correcting color comment

### DIFF
--- a/spec/Vehicle/Vehicle.vspec
+++ b/spec/Vehicle/Vehicle.vspec
@@ -130,7 +130,7 @@
 - VehicleIdentification.vehicleinteriorColor:
   datatype: string
   type: attribute
-  description: A short text indicating the configuration of the vehicle, e.g. '5dr hatchback ST 2.5 MT 225 hp' or 'limited edition'.
+  description: The color or color combination of the interior of the vehicle.
 
 - VehicleIdentification.vehicleinteriorType:
   datatype: string


### PR DESCRIPTION
Previous comment must be a copy paste error.
Now using comment from https://schema.org/Car

It can by the way be discussed to change `interior` to `Interior` (capital I) to be consistent with capitalization in schema.org where the name is e.g. `vehicleInteriorColor`