### PR TITLE
Add links to view versions 2.0 and 2.1  of spec in online JSON editor

### DIFF
--- a/docs-gen/content/introduction/quickstart.md
+++ b/docs-gen/content/introduction/quickstart.md
@@ -8,6 +8,10 @@ A serialization of the data definition of the vehicle signal specification is ch
 as ```vss_$VERSION.json```, where ```$VERSION``` is the content of
 the ```VERSION``` file.
 
-A web-based JSON viewer can be used to view the current version.
+A web-based JSON viewer can be used to view the spec.
 
-Click **[here](https://jsoneditoronline.org/?url=https://raw.githubusercontent.com/GENIVI/vehicle_signal_specification/746bbadc303ffa0645d4b547af925a041b25aa08/vss_rel_1.0.json)**
+
+- View [VSS version 2.1](https://jsoneditoronline.org/?url=https://genivi.github.io/vehicle_signal_specification/releases/v2.1/vss_release_2.1.json)
+- View  [VSS version 2.0](https://jsoneditoronline.org/?url=https://genivi.github.io/vehicle_signal_specification/releases/v2.0/vss_release_2.0.json)
+- View  [VSS version 1.0](https://jsoneditoronline.org/?url=https://genivi.github.io/vehicle_signal_specification/releases/v1.0/vss_rel_1.0.json)
+


### PR DESCRIPTION
Should fix #287 

