### PR TITLE
Makefile: Add target for graphql

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@
 # Makefile to generate specifications
 #
 
-.PHONY: clean all travis_targets json franca csv tests binary protobuf ttl ocf c install deploy
+.PHONY: clean all travis_targets json franca csv tests binary protobuf ttl graphql ocf c install deploy
 
-all: clean json franca csv binary tests protobuf
+all: clean json franca csv binary tests protobuf graphql
 
 # All mandatory targets that shall be built and pass on each pull request for
 # vehicle-signal-specification or vss-tools
@@ -17,7 +17,7 @@ travis_targets: clean json franca binary csv tests deploy
 # from time to time
 # Can be run from e.g. travis with "make -k travis_optional || true" to continue
 # even if errors occur and not do not halt travis build if errors occur
-travis_optional: clean c ocf protobuf ttl
+travis_optional: clean c ocf protobuf ttl graphql
 
 DESTDIR?=/usr/local
 TOOLSDIR?=./vss-tools
@@ -43,6 +43,9 @@ binary:
 
 protobuf:
 	${TOOLSDIR}/contrib/vspec2protobuf.py  -I ./spec ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).proto
+
+graphql:
+	${TOOLSDIR}/contrib/vspec2graphql.py -i:spec/VehicleSignalSpecification.id -I ./spec ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).graphql.ts
 
 ocf:
 	${TOOLSDIR}/contrib/ocf/vspec2ocf.py -I ./spec ./spec/VehicleSignalSpecification.vspec vss_rel_$$(cat VERSION).ocf.json


### PR DESCRIPTION
Note that this also updates the vss-tools submodule to include the
contrib/vspec2graphql.py, so that the new target can also be tested by CI.

If the graphql tool gets merged first (fast-forward), then the submodule hash will match and this can be merged directly.  If not, the submodule needs update in this PR before merging it.
