### PR TITLE
online doc: fix links, spelling and formatting

### DIFF
--- a/docs-gen/content/introduction/taxonomy.md
+++ b/docs-gen/content/introduction/taxonomy.md
@@ -13,8 +13,11 @@ taxonomies can be seen as second step.
 
 ## Components of a domain taxonomy
 A domain taxonomy, like VSS, consists of three important components, which will be
-discussed in detail in this documentation:\\
-**1. Rule Set**, as definition on how to describe the data definition syntactically. \\
-**2. Data Definition**, as description of the domain as a simple graph. \\
+discussed in detail in this documentation:
+
+**1. Rule Set**, as definition on how to describe the data definition syntactically.
+
+**2. Data Definition**, as description of the domain as a simple graph.
+
 **3. Tools and Serialization**, generates the serialization out of the data Definition
    for further usage.

--- a/docs-gen/content/rule_set/_index.md
+++ b/docs-gen/content/rule_set/_index.md
@@ -6,6 +6,6 @@ chapter: true
 
 # Rule Set
 
-The `Rule Set` of a domain taxonomy is [used](/introduction/taxonomies) to describe how to write the data definition syntactically.
+The `Rule Set` of a domain taxonomy is [used](/vehicle_signal_specification/introduction/taxonomies) to describe how to write the data definition syntactically.
 
 In this chapter you learn about the rule set for VSS.

--- a/docs-gen/content/rule_set/_index.md
+++ b/docs-gen/content/rule_set/_index.md
@@ -6,6 +6,6 @@ chapter: true
 
 # Rule Set
 
-The `Rule Set` of a domain taxonomy is [used](/vehicle_signal_specification/introduction/taxonomies) to describe how to write the data definition syntactically.
+The `Rule Set` of a [domain taxonomy](/vehicle_signal_specification/introduction/taxonomy/) is used to describe how to write the data definition syntactically.
 
 In this chapter you learn about the rule set for VSS.

--- a/docs-gen/content/rule_set/data_entry/_index.md
+++ b/docs-gen/content/rule_set/data_entry/_index.md
@@ -11,7 +11,7 @@ In order to help application developers, who are using the specification, it mak
 The difference between a signal and an attribute is that the signal has
 a publisher (or producer) that continuously updates the signal value while an
 attribute has a set value, defined in the specification, that never changes.
-As summary, besides [```branch```](/rule_set/branches) type can be:
+As summary, besides [```branch```](/vehicle_signal_specification/rule_set/branches) type can be:
 
 * **```attribute```**: attributes are not expected to change once they're set (e.g. vehicle identification number)
 * **```sensor```**: sensor values describe the current state of the vehicle and change over time, as the state of the vehicle changes (e.g. odometer).

--- a/docs-gen/content/rule_set/data_entry/_index.md
+++ b/docs-gen/content/rule_set/data_entry/_index.md
@@ -7,7 +7,7 @@ weight: 2
 
 # Data Entry
 Leaf nodes of the tree contain metadata describing the data associated to the node.
-In order to help application developers, who are using the specification, it makes a distinction between signals - in the following as ```sensor```, ```actuator``` and ```stream``` - and ```attribute```.
+In order to help application developers, who are using the specification, it makes a distinction between signals - in the following as [```sensor```](/vehicle_signal_specification/rule_set/data_entry/sensor_actuator), [```actuator```](/vehicle_signal_specification/rule_set/data_entry/sensor_actuator) and [```stream```](/vehicle_signal_specification/rule_set/data_entry/data_types/#data-streams) - and [```attribute```](/vehicle_signal_specification/rule_set/data_entry/attributes).
 The difference between a signal and an attribute is that the signal has
 a publisher (or producer) that continuously updates the signal value while an
 attribute has a set value, defined in the specification, that never changes.

--- a/docs-gen/content/rule_set/data_entry/data_types.md
+++ b/docs-gen/content/rule_set/data_entry/data_types.md
@@ -4,7 +4,7 @@ date: 2019-08-04T11:11:48+02:00
 weight: 1
 ---
 
-Each [data entry](/vehicle_signal_specification/rule_set/data_entry) specifies a ```datatype``` from the following set (from FrancaIDL). Datatypes shall not be used in [branch entry](/vehicle_signal_specification/rule_set/branches)
+Each [data entry](/vehicle_signal_specification/rule_set/data_entry) specifies a ```datatype``` from the following set (from Franca IDL). Datatypes shall not be used in [branch entry](/vehicle_signal_specification/rule_set/branches)
 
 ## Supported datatypes
 

--- a/docs-gen/content/rule_set/includes.md
+++ b/docs-gen/content/rule_set/includes.md
@@ -48,7 +48,7 @@ they are included.
 An example is given in Fig 7 where a generic door signal specification is
 included four times to describe all doors in the vehicle.
 
-![Include directrive](/vehicle_signal_specification/images/spec_file_reuse.png)<br>
+![Include directive](/vehicle_signal_specification/images/spec_file_reuse.png)<br>
 *Fig 7. Reusing signal trees*
 
 The ```door.vspec``` file is included four times by the master ```root.vspec``` file.


### PR DESCRIPTION
Fix some miscellaneous errors related to broken links, spelling and formatting in the online doc. See commit msgs for details.

Did some manual render testing and the changes seem to work. Whilst setting up for that I spotted a documentation gap around the Hugo versions for which I will raise an separate issue.