### PR TITLE
Fixing imports

### DIFF
--- a/spec/Cabin/Occupant.vspec
+++ b/spec/Cabin/Occupant.vspec
@@ -11,4 +11,4 @@
 Identifier:
   type: branch
   description: Identifier attributes based on OAuth 2.0.
-#include Identifier/Identifier.vspec Identifier
+#include ../Identifier/Identifier.vspec Identifier

--- a/spec/Driver/Driver.vspec
+++ b/spec/Driver/Driver.vspec
@@ -9,7 +9,7 @@
 #
 
 
-#include Cabin/Occupant.vspec
+#include ../Cabin/Occupant.vspec
 
 DistractionLevel:
   datatype: float


### PR DESCRIPTION
In these two files the relative import is incorrect, since:

1. There is no Identifier/ folder inside Cabin, where resides
   Occupant.vspec
2. There is no Cabin/ folder inside Driver/, where resides
   Driver.vspec