### PR TITLE
Type fix: uint32 -> int32 for signed values

### DIFF
--- a/spec/Powertrain/ElectricMotor.vspec
+++ b/spec/Powertrain/ElectricMotor.vspec
@@ -52,7 +52,7 @@ Motor:
 # Motor rotations per minute
 #
 Motor.Rpm:
-  datatype: uint32
+  datatype: int32
   type: sensor
   unit: rpm
   min: -100000


### PR DESCRIPTION
my validation tool found this error since I use this signals database as a sample