### PR TITLE
Changing seat instantiation and improving default value documentation

### DIFF
--- a/docs-gen/content/rule_set/data_entry/attributes.md
+++ b/docs-gen/content/rule_set/data_entry/attributes.md
@@ -6,11 +6,15 @@ weight: 4
 
 An attribute is a signal with a default value, specified by
 its ```default``` member.
+The standard Vehicle Signal Specification include default values for most attributes. 
+It is expected that these default values do not fit all values.
+This means that an OEM must override the standard default values if a vehicle needs a different value.
 
 Attribute values can also change, similar to sensor values.
 The latter can be useful for attribute values that are likely to change during the lifetime of the vehicle.
 However, attribute values should typically not change more than once per ignition cycle,
 or else it should be defined as a sensor instead.
+
 
 Below is an example of a complete attribute describing engine power
 
@@ -21,4 +25,28 @@ MaxPower:
   default: 0
   unit: kW
   description: Peak power, in kilowatts, that engine can generate.
+```
+
+It is possible to give default values also for arrays. In this case square brackets shall be used. The value for each element in the array shall be specified. The size of the array is given by the number of elements specified within the square brackets.
+
+Example 1: Empty Array
+
+```YAML
+  default: []
+```
+
+Example 2: Array with 3 elements, first element has value 1, second element value 2, third element value 0
+
+```YAML
+  default: [1, 2, 0]
+```
+
+Full example, array with two elements, first with value2, second with value 3:
+
+```YAML
+SeatPosCount:
+  datatype: uint8[]
+  type: attribute
+  default: [2, 3]
+  description: Number of seats across each row from the front to the rear
 ```

--- a/spec/Cabin/Cabin.vspec
+++ b/spec/Cabin/Cabin.vspec
@@ -94,64 +94,83 @@ Lights:
 
 ##
 # Door signals and attributes
+# The default VSS (i.e. this file) assumes a vehicle with two rows of doors
+# with two doors in front row and two doors in second row.
+# For real deployments this needs to be overridden with actual values
+# Row1 is the frontmost row.
+# Row2-RowX are subsequent rows of doors.
+#
+# Note that rear door (for hatchback and station wagons) shall typically not be represented
+# as a door, but rather be represented as a trunk (Vehicle.Body.Trunk) and
+# rear shade (Vehicle.Cabin.RearShade)
 ##
 Door:
   type: branch
   instances:
-    - Row[1,4]
+    - Row[1,2]
     - ["Left","Right"]
   description: All doors, including windows and switches
 #include SingleDoor.vspec Door
 
+# Default value based on instance declaration above with 2 rows and 2 doors in each row.
 DoorCount:
   datatype: uint8
   type: attribute
-  default: 0
+  default: 4
   description: Number of doors in vehicle
 
 
 
 ##
 # Seat signals and attributes
+# The default VSS (i.e. this file) assumes a vehicle with two rows of seats
+# with two seats in front row and three seats in second row.
+# For real deployments this needs to be overridden with actual values
 # Row1 is the frontmost row.
-# Row2-Row4 are subsequent rows of seats.
+# Row2-RowX are subsequent rows of seats.
 #
-# Within each row there are five seat positions
+# Within each row there are up to Y seat positions
 # Pos1 is leftmost.
-# Pos5 is rightmost.
+# PosY is rightmost.
+#
+# The value of Y shall consider the row with most number of seats in the vehicle.
+# If a vehicle e.g. have 2 seats in front row and 3 seats in second row, then Pos
+# shall be defined as Pos[1,3]
+# Which seats that actually exist can be defined by SeatPosCount
 ##
 
 Seat:
   type: branch
   instances:
-    - Row[1,4]
-    - Pos[1,5]
+    - Row[1,2]
+    - Pos[1,3]
   description: All seats.
 #include SingleSeat.vspec Seat
 
 #
 # Seat attributes.
 #
+# Default value is position 1, i.e. a typical LHD vehicle
 DriverPosition:
   datatype: uint8
   type: attribute
-  default: 0
-  description: The position of the driver seat in row 1. (1-5)
+  default: 1
+  description: The position of the driver seat in row 1.
 
+# Default value corresponds to two rows of seats
 SeatRowCount:
   datatype: uint8
   type: attribute
-  default: 0
+  default: 2
   description: Number of seat rows in vehicle
 
 
+# Default value corresponds to two seats in front row and 3 seats in second row
 SeatPosCount:
   datatype: uint8[]
   type: attribute
-  default: 0
+  default: [2, 3]
   description: Number of seats across each row from the front to the rear
-
-
 
 ##
 # Convertible roof status

--- a/spec/Cabin/SingleShade.vspec
+++ b/spec/Cabin/SingleShade.vspec
@@ -8,7 +8,7 @@
 
 #
 # Definition of a single blind / curtain that can cover either
-# a side window or the rear window.
+# a side window, the rear window or a sunroof.
 #
 
 # Include a slider control switch for the blind
@@ -20,4 +20,4 @@ Position:
   min: 0
   max: 100
   unit: percent
-  description: Position of side window blind. 0 = Fully retracted. 100 = Fully deployed.
+  description: Position of window blind. 0 = Fully retracted. 100 = Fully deployed.

--- a/spec/Cabin/SingleWindow.vspec
+++ b/spec/Cabin/SingleWindow.vspec
@@ -12,7 +12,7 @@
 isOpen:
   datatype: boolean
   type: sensor
-  description: Is door open or closed
+  description: Is window open or closed
 
 Position:
   datatype: uint8
@@ -25,7 +25,7 @@ Position:
 ChildLock:
   datatype: boolean
   type: sensor
-  description: Is door child lock engaged. True = Engaged. False = Disengaged.
+  description: Is window child lock engaged. True = Engaged. False = Disengaged.
 
 # Include the window controlling switch and attach it to the
 # window branch


### PR DESCRIPTION
Content of this change:

- Improved documentation on how to set default values for array
- Changing default values for seats/doors. Now default corresponds to a classical passenger car with 2 rows of seats, 2 seats in front row and 3 in back row. That reduces the size of generated "standard VSS" significantly.

Fixes #329

Example on how generated JSON with new default looks like:
```
 "SeatPosCount": {
            "datatype": "uint8[]",
            "default": [
              2,
              3
            ],
            "description": "Number of seats across each row from the front to the rear",
            "type": "attribute",
            "uuid": "8dd40ecd47ab51c79ed9c74ae4296d7e"
          },
```